### PR TITLE
simulate and predictLVs functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: gllvm
 Type: Package
 Title: Generalized Linear Latent Variable Models
-Version: 1.1.3
+Version: 1.1.4
+Date: 2019-05-06
 Author: Jenni Niku, Wesley Brooks, Riki Herliansyah, Francis K.C. Hui, Sara Taskinen, David I. Warton
 Maintainer: Jenni Niku <jenni.m.e.niku@jyu.fi>
 Description: Analysis of multivariate data using generalized linear latent variable models (gllvm). 

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -506,6 +506,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL,
       }
 
       out$X.design <- fitg$X.design
+      out$TMBfn = fitg$TMBfn
       out$logL <- fitg$logL
       if (num.lv > 0)
         out$lvs <- fitg$lvs

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -580,6 +580,10 @@ gllvm.TMB <- function(y, X = NULL, formula = NULL, num.lv = 2, family = "poisson
 
   if(is.null(formula1)){ out$formula <- formula} else {out$formula <- formula1}
 
+  
+  # DW, 7/5/19: adding TMBfn to output:
+  out$TMBfn <- objr
+  out$TMBfn$par <- optr$par #ensure params in this fn take final values
   out$logL <- -out$logL
   return(out)
 }

--- a/R/predict.gllvm.R
+++ b/R/predict.gllvm.R
@@ -140,7 +140,8 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
       eta <- eta + object$lvs %*% t(theta)
     if(!is.null(newLV)) {
       if(ncol(newLV) != object$num.lv) stop("Number of latent variables in input doesn't equal to the number of latent variables in the model.")
-      if(nrow(newLV) != nrow(Xnew)) stop("Number of rows in newLV must equal to the number of rows in newX, if newX is included, otherwise same as number of rows in the response matrix.")
+      if(is.null(newdata)==FALSE) #DW addition, 6/5/19: so no error here for intercept models
+      {  if(nrow(newLV) != nrow(Xnew)) stop("Number of rows in newLV must equal to the number of rows in newX, if newX is included, otherwise same as number of rows in the response matrix.") }
       lvs <- newLV
       eta <- eta + lvs %*% t(theta)
     }

--- a/R/predictLVs.gllvm.R
+++ b/R/predictLVs.gllvm.R
@@ -1,0 +1,63 @@
+predictLVs.gllvm = function (object, newX = if(is.null(object$X)) NULL else object$X, newY=object$y, ...) 
+{
+  # create a gllvm object which refits the model using newX and newY:
+  assign(as.character(object$call[2]),newY)
+  if(is.null(newX)==FALSE)
+    assign(as.character(object$call[3]),newX)
+  objectTest=eval(object$call)
+
+  # now optimise for LV parameters, keeping all else constant:
+  objParam=object$TMBfn$par
+  optLVs=optim(objParam,logL4lvs,gr=objectTest$TMBfn$gr,objectTest,object,method="BFGS")
+  
+  # now find the LV estimates to report:
+  ui <- names(optLVs$par)=="u"
+  n <- dim(objectTest$y)[1]
+  lvs <- (matrix(optLVs$par[ui],n,objectTest$num.lv))
+  rownames(lvs) <- rownames(objectTest$y);
+  if(objectTest$num.lv>1) colnames(lvs) <- paste("LV", 1:objectTest$num.lv, sep="");
+
+  # and their sds: (assuming method="VA")
+  if(objectTest$num.lv>0)
+  {
+    Au <- optLVs$par[names(optLVs$par)=="Au"]
+    A <- array(0,dim=c(n,objectTest$num.lv,objectTest$num.lv))
+    for (d in 1:objectTest$num.lv)
+    {
+      for(i in 1:n)
+      {
+        A[i,d,d] <- exp(Au[(d-1)*n+i]);
+      }
+    }
+    if(length(Au)>objectTest$num.lv*n)
+    {
+      k <- 0;
+      for (c1 in 1:objectTest$num.lv)
+      {
+        r <- c1+1;
+        while (r <=objectTest$num.lv)
+        {
+          for(i in 1:n)
+          {
+            A[i,r,c1] <- Au[objectTest$num.lv*n+k*n+i];
+            A[i,c1,r] <- A[i,r,c1];
+          }
+          k <- k+1; r <- r+1;
+        }
+      }
+    }
+  }
+  return(list(lvs=lvs,A=A))
+}
+
+logL4lvs = function(pars,objectTest,object)
+{
+  whichNotLVs = names(object$TMBfn$par)!="u" & names(object$TMBfn$par)!="Au"
+  pars[whichNotLVs] = object$TMBfn$par[whichNotLVs]
+  objectTest$TMBfn$fn(pars)
+}
+
+# to check:
+# example(gllvm) # escape out of it after the second model, fitv0, has been fitted
+# predictLVs.gllvm(fit,newX=fit$X,newY=simulate.gllvm(fit))
+# predictLVs.gllvm(fitv0,newY=simulate.gllvm(fitv0))

--- a/R/simulate.gllvm.R
+++ b/R/simulate.gllvm.R
@@ -1,0 +1,50 @@
+# simulate function for gllvm objects.  Note this simulates marginally over LVs.
+# an option is to add a conditional argument, which would fix the LVs.
+# David Warton
+# last modified 6th May 2019
+
+simulate.gllvm = function (object, nsim = 1, seed = NULL, ...) 
+{
+  # code chunk from simulate.lm to sort out the seed thing:
+  if (!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) 
+    runif(1)
+  if (is.null(seed)) 
+    RNGstate <- get(".Random.seed", envir = .GlobalEnv)
+  else {
+    R.seed <- get(".Random.seed", envir = .GlobalEnv)
+    set.seed(seed)
+    RNGstate <- structure(seed, kind = as.list(RNGkind()))
+    on.exit(assign(".Random.seed", R.seed, envir = .GlobalEnv))
+  }
+  
+  nRows = dim(object$lvs)[1]
+  nCols = dim(object$params$theta)[1]
+  # generate new latent variables
+  lvsNew = matrix(rnorm(nsim*nRows*object$num.lv),ncol=object$num.lv)
+  if(is.null(object$X)) # for intercept models, there is a bug in predict fn so loop nsim times as a workaround
+  {
+     prs = matrix(NA,nsim*nRows,nCols)
+     for(iSim in 1:nsim)
+     {
+       whichRows = (iSim-1)*nRows+1:nRows
+       prTemp = predict.gllvm(object,newLV = lvsNew[whichRows,],type="response")
+       prs[whichRows,] = prTemp
+     }
+     dimnames(prs) = list(1:(nsim*nRows),dimnames(prTemp)[[2]]) #match up column names
+  }
+  else
+    prs = predict.gllvm(object,newX=object$X[rep(1:nRows,nsim),], newLV = lvsNew,type="response")
+    
+  # generate new data
+  nTot = nsim*nRows*nCols # total number of values to generate
+  if(object$family=="negative.binomial")
+    invPhis = matrix(rep(object$params$inv.phi,each=nsim*nRows), ncol=nCols)
+  newDat = switch(object$family,"binomial"=rbinom(nTot,size=1,prob=prs),
+                  "poisson"=rpois(nTot,prs),
+                  "negative.binomial"=rnbinom(nTot,size=invPhis,mu=prs),
+                  stop(gettextf("family '%s' not implemented ", object$family), domain = NA))
+  # reformat as data frame with the appropriate labels
+  newDat = as.data.frame(matrix(newDat,ncol=nCols))
+  dimnames(newDat)=dimnames(prs)
+  return(newDat)
+}

--- a/src-i386/gllvm.cpp
+++ b/src-i386/gllvm.cpp
@@ -1,0 +1,224 @@
+#define TMB_LIB_INIT R_init_gllvm
+#include <TMB.hpp>
+#include<math.h>
+//--------------------------------------------------------
+//GLLVM
+//Author: Jenni Niku
+//------------------------------------------------------------
+template<class Type>
+Type objective_function<Type>::operator() ()
+{
+  //declares all data and parameters used
+  DATA_MATRIX(y);
+  DATA_MATRIX(x);
+  DATA_MATRIX(xr);
+  DATA_MATRIX(offset);
+
+  PARAMETER_MATRIX(r0);
+  PARAMETER_MATRIX(b);
+  PARAMETER_MATRIX(B);
+  PARAMETER_VECTOR(lambda);
+
+  //latent variables, u, are treated as parameters
+  PARAMETER_MATRIX(u);
+  PARAMETER_VECTOR(lg_phi);
+  PARAMETER(log_sigma);// log(SD for row effect)
+
+  DATA_INTEGER(num_lv);
+  DATA_INTEGER(family);
+
+  PARAMETER_VECTOR(Au);
+  PARAMETER_VECTOR(lg_Ar);
+  DATA_SCALAR(extra);
+  DATA_INTEGER(method);// 0=VA, 1=LA
+  DATA_INTEGER(model);
+  DATA_VECTOR(random);//random row
+
+  int n = y.rows();
+  int p = y.cols();
+  vector<Type> iphi = exp(lg_phi);
+  vector<Type> Ar = exp(lg_Ar);
+  Type sigma = exp(log_sigma);
+
+  if(random(0)<1){  r0(0,0) = 0;}
+
+  matrix<Type> eta(n,p);
+
+  matrix<Type> newlam(num_lv,p);
+  if(num_lv>0){
+
+    for (int j=0; j<p; j++){
+      for (int i=0; i<num_lv; i++){
+        if (j < i){
+          newlam(i,j) = 0;
+        } else{
+          newlam(i,j) = lambda(j);
+          if (i > 0){
+            newlam(i,j) = lambda(i+j+i*p-(i*(i-1))/2-2*i);
+          }
+        }
+      }
+    }
+
+    //To create lambda as matrix upper triangle
+
+    matrix<Type> lam = u*newlam;
+    eta = lam;
+  }
+
+  matrix<Type> mu(n,p);
+
+  Type nll = 0.0; // initial value of log-likelihood
+
+
+  if(method<1){
+    eta += r0*xr + offset;
+
+    matrix<Type> cQ(n,p);
+
+    if(random(0)>0){
+      for (int i=0; i<n; i++) {
+        Ar(i)=pow(Ar(i),2);
+        for (int j=0; j<p;j++){
+          cQ(i,j) = 0.5* Ar(i);//
+        }
+      }}
+
+    if(num_lv>0){
+      array<Type> A(num_lv,num_lv,n);
+      for (int d=0; d<(num_lv); d++){
+        for(int i=0; i<n; i++){
+          A(d,d,i)=exp(Au(d*n+i));
+        }
+      }
+      if(Au.size()>num_lv*n){
+        int k=0;
+        for (int c=0; c<(num_lv); c++){
+          for (int r=c+1; r<(num_lv); r++){
+            for(int i=0; i<n; i++){
+              A(r,c,i)=Au(num_lv*n+k*n+i);
+              A(c,r,i)=A(r,c,i);
+            }
+            k++;
+          }}
+      }
+      /*Calculates the commonly used (1/2) theta'_j A_i theta_j
+      A is a num.lv x nmu.lv x n array, theta is p x num.lv matrix*/
+      for (int i=0; i<n; i++) {
+        for (int j=0; j<p;j++){
+          cQ(i,j) += 0.5*((newlam.col(j)).transpose()*(A.col(i).matrix()*newlam.col(j))).sum();
+        }
+        nll -= 0.5*(log(A.col(i).matrix().determinant()) - A.col(i).matrix().diagonal().sum());// log(det(A_i))-sum(trace(A_i))*0.5 sum.diag(A)
+      }
+
+    }
+
+    if(model<1){
+      eta += x*b;
+    } else {
+      matrix<Type> eta1=x*B;
+      int m=0;
+      for (int j=0; j<p;j++){
+        for (int i=0; i<n; i++) {
+          eta(i,j)+=b(0,j)+eta1(m,0);
+          m++;
+        }
+      }
+    }
+    //likelihood
+    if(family<1){
+      for (int i=0; i<n; i++) {
+        for (int j=0; j<p;j++){
+          nll -= dpois(y(i,j), exp(eta(i,j)+cQ(i,j)), true)-y(i,j)*cQ(i,j);
+        }
+        nll -= 0.5*(log(Ar(i)) - Ar(i)/pow(sigma,2) - pow(r0(i)/sigma,2))*random(0);
+      }
+    } else if(family<2){
+      for (int i=0; i<n; i++) {
+        for (int j=0; j<p;j++){
+          nll -= y(i,j)*(eta(i,j)-cQ(i,j)) - (y(i,j)+iphi(j))*log(iphi(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(y(i,j)+iphi(j)) - iphi(j)*cQ(i,j) + iphi(j)*log(iphi(j)) - lgamma(iphi(j)) -lfactorial(y(i,j));
+        }
+        nll -= 0.5*(log(Ar(i)) - Ar(i)/pow(sigma,2) - pow(r0(i)/sigma,2))*random(0);
+      }
+    } else {
+      for (int i=0; i<n; i++) {
+        for (int j=0; j<p;j++){
+          mu(i,j) = pnorm(Type(eta(i,j)),Type(0),Type(1));
+          nll -= log(pow(mu(i,j),y(i,j))*pow(1-mu(i,j),(1-y(i,j)))) - cQ(i,j);
+        }
+        nll -= 0.5*(log(Ar(i)) - Ar(i)/pow(sigma,2) - pow(r0(i)/sigma,2))*random(0);
+      }
+    }
+    nll -= -0.5*(u.array()*u.array()).sum() - n*log(sigma)*random(0);// -0.5*t(u_i)*u_i
+
+
+  } else {
+    eta += r0*xr + offset;
+
+    if(model<1){
+
+      eta += x*b;
+      for (int j=0; j<p; j++){
+        for(int i=0; i<n; i++){
+          mu(i,j) = exp(eta(i,j));
+        }
+      }
+    } else {
+
+      matrix<Type> eta1=x*B;
+      int m=0;
+      for (int j=0; j<p;j++){
+        for (int i=0; i<n; i++) {
+          eta(i,j)+=b(0,j)+eta1(m,0);
+          m++;
+          mu(i,j) = exp(eta(i,j));
+        }
+      }
+    }
+    //latent variable is assumed to be from N(0,1)
+    if(num_lv>0){
+      for (int j=0; j<u.cols();j++){
+        for (int i=0; i<n; i++) {
+          nll -= dnorm(u(i,j),Type(0),Type(1),true);
+        }
+      }}
+    for(int i = 0; i < n; i++){
+      nll -= dnorm(r0(i,0), Type(0), sigma, true)*random(0);
+    }
+
+    //likelihood model with the log link function
+    if(family<1){
+      for (int j=0; j<p;j++){
+        for (int i=0; i<n; i++) {
+          nll -= dpois(y(i,j), exp(eta(i,j)), true);
+        }
+      }
+    } else if(family<2){
+      for (int j=0; j<p;j++){
+        for (int i=0; i<n; i++) {
+          nll -= y(i,j)*(eta(i,j)) - y(i,j)*log(iphi(j)+mu(i,j))-iphi(j)*log(1+mu(i,j)/iphi(j)) + lgamma(y(i,j)+iphi(j)) - lgamma(iphi(j)) -lfactorial(y(i,j));
+        }
+      }} else if(family<3) {
+        for (int j=0; j<p;j++){
+          for (int i=0; i<n; i++) {
+            if(extra<1) {mu(i,j) = mu(i,j)/(mu(i,j)+1);
+            } else {mu(i,j) = pnorm(eta(i,j));}
+            nll -= log(pow(mu(i,j),y(i,j))*pow(1-mu(i,j),(1-y(i,j))));
+          }
+        }
+      } else if(family<4){
+        for (int j=0; j<p;j++){
+          for (int i=0; i<n; i++) {
+            nll -= dtweedie(y(i,j), exp(eta(i,j)),iphi(j),extra, true); //tweedie family
+          }
+        }
+      }else {
+        iphi=iphi/(1+iphi);
+        for (int j=0; j<p;j++){
+          for (int i=0; i<n; i++) {
+            nll -= dzipois(y(i,j), exp(eta(i,j)),iphi(j), true); //zero-infl-poisson
+          }
+        }}
+  }
+  return nll;
+}


### PR DESCRIPTION
- drafted a simulate function, and predictLVs.gllvm, to predict lvs for new Ys.
- added a TMBfn to gllvm output so you can access the original function optimised (needed to predict LVs)
- predictLVs needs more bells and whistles, suggest that it be cleaned up a bit and added to predict.gllvm as type="lv" or similar...
- simulate.gllvm comes with no documentation, the intention is that it behave like generic simualte, although optionally we could add a "conditional" input argument which fixes lvs (conditional=TRUE) or simulates them (conditional=FALSE, amounting to glm simulation, unless we simulated from the posterior for the lv...).  Currently it only does cond=FALSE.