### PR TITLE
Bugfix, added error and dredging

### DIFF
--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -35,14 +35,15 @@ gllvm.TMB <- function(y, X = NULL, formula = NULL, num.lv = 2, family = "poisson
   if (is.null(colnames(y)))
     colnames(y) <- paste("Col", 1:p, sep = "")
   if(family == "ordinal") {
-    y00<-y
+     y00<-y
     if(min(y)==0){ y=y+1}
     max.levels <- apply(y,2,function(x) length(min(x):max(x)))
     if(any(max.levels == 1)&zeta.struc=="species" || all(max.levels == 2)&zeta.struc=="species")
       stop("Ordinal data requires all columns to have at least has two levels. If all columns only have two levels, please use family == binomial instead. Thanks")
     if(any(!apply(y,2,function(x)all(diff(sort(unique(x)))==1)))&zeta.struc=="species")
       stop("Can't fit ordinal model if there are species with missing classes. Please reclassify per species or use zeta.struc = `common` ")
-    
+    if(!all(min(y)==apply(y,2,min))&zeta.struc=="species")
+      stop("For ordinal data and zeta.struc=`species` all species must have the same minimum category. Please reclassify per species or use zeta.struc = `common`."
     if(any(diff(sort(unique(c(y))))!=1)&zeta.struc=="common")
       stop("Can't fit ordinal model if there are missing classes. Please reclassify.")
   }

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -370,7 +370,7 @@ gllvm.TMB <- function(y, X = NULL, formula = NULL, num.lv = 2, family = "poisson
           idx<-idx+k
         }
         zetanew[,1] <- 0 
-        row.names(zetanew) <- colnames(y00); colnames(zetanew) <- paste(min(y):(max(y00)-1),"|",(min(y00)+1):max(y00),sep="")
+        row.names(zetanew) <- colnames(y00); colnames(zetanew) <- paste(min(y00):(max(y00)-1),"|",(min(y00)+1):max(y00),sep="")
         }else{
           zetanew <- c(0,zetas)
           names(zetanew) <- paste(min(y00):(max(y00)-1),"|",(min(y00)+1):max(y00),sep="")

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -1393,3 +1393,11 @@ mlm <- function(y, X = NULL, index = NULL){
   out$residuals <- residuals
   out
 }
+                                 
+nobs.gllvm <- function(object){
+n <- dim(object$y)[1]
+return(n)
+}
+##' @importFrom stats nobs
+##' @export
+

--- a/vignettes/vignette1.Rmd
+++ b/vignettes/vignette1.Rmd
@@ -231,6 +231,21 @@ coefplot(fit_env, cex.ylab = 0.7, xlim.list = list(NULL, NULL, c(-4, 4)),
 rownames(fit_env$params$Xcoef) <- colnames(fit_env$y)
 ```
 
+Alternatively, model-selection on covariates, latent variables or both can be performed by dredging, using the MuMIn package. Though especially for large datasets with many covariates and latent variables, this can take a while to run.
+```{r, eval = FALSE, warning = FALSE}
+library(MuMIn)
+fit_table <- dredge(fiti,varying=list(num.lv=1:5), rank="AIC")
+subset(fit_table, delta<2)
+# Global model call: gllvm(y = y, X = X, formula = ~Bare.ground + Shrub.cover + Volume.lying.CWD, 
+#     num.lv = i, family = "negative.binomial", sd.errors = FALSE, 
+#     seed = 1234)
+# ---
+# Model selection table 
+#    (Int) Bar.grn Shr.cvr Vlm.lyn.CWD num.lv  df    logLik   AICc delta weight
+# 39     +       +       +           +      4 363 -1793.923 3522.6  0.00   0.52
+# 38     +       +       +           +      3 325 -1794.337 3522.8  0.16   0.48
+# Models ranked by AICc(x) 
+```
 
 ## Studying co-occurrence patterns
 


### PR DESCRIPTION
1) Fixed a bug causing zeta to have wrong column names with zeta.struc ="species"
2) Added an error to be thrown if zeta.struc="species" and when not all species have the same starting category (this otherwise causes a R crash due to the implementation in TMB)
3) Added a simple nobs.gllvm function in gllvm.auxiliary that retrieves the number of sites (obs). This facilitates use of the "dredge" function in the MuMIn package for automatic selection of covariates and the number of latent variables. Only works when starting.val is not provided. This could potentially try different starting values, though the current implementation of dredge() only seems to allow additional components (outside the model formula) that are either numeric or character (otherwise transforms the numeric into a character which causes issues for gllvm()).
4) Added a (very) simple dredging example to vignette1.