### PR TITLE
Constrained gllvm minor bugfixes

### DIFF
--- a/R/getLV.gllvm.R
+++ b/R/getLV.gllvm.R
@@ -2,7 +2,7 @@
 #' @description  Extract latent variables from gllvm object.
 #' 
 #' @param object an object of class 'gllvm'.
-#' @param type type of latent variable scores to retrieve from a gllvm object. For models with unconstrained latent variables, defaults to "unconstrained". For models with constrained latent variables, defaults to "constrained". A third option is "scaled", which returns latent variables multiplied with their standard deviations.
+#' @param type type of latent variable scores to retrieve from a gllvm object. For models with unconstrained latent variables, defaults to "unconstrained". For models with constrained latent variables, defaults to "constrained". A third option is "scaled", which returns latent variables multiplied with their standard deviations. Alternatively, "LC" returns linear combination scores without residual error.
 #' @param ... not used
 #' 
 #'@aliases getLV getLV.gllvm
@@ -43,6 +43,8 @@ getLV.gllvm <- function(object, type = NULL, ...)
         lvs <- matrix(0,ncol=object$num.RR,nrow=n)
       }
     }
+  }else if(type=="LC"){
+    lvs <- object$lv.X%*%object$params$LvXcoef
   }
   if((object$num.lv.c+object$num.RR)>0){
     lvs<-cbind(object$lv.X%*%object$params$LvXcoef+lvs[,1:(object$num.lv.c+object$num.RR)],lvs[,-c(1:(object$num.lv.c+object$num.RR))])

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -319,7 +319,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
                   ) {
     #change default behavior of num.lv.
     #if num.lv.c>0, num.lv defaults to 0 if it is 0. Otherwise, it defaults to 2
-  if(is.null(num.lv)&num.lv.c==0){
+  if(is.null(num.lv)&num.lv.c==0&num.RR==0){
     num.lv <- 2
   }else if(is.null(num.lv)){num.lv<-0}
   
@@ -451,9 +451,9 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
         } else if(is.null(formula)&is.null(lv.formula)&(num.lv.c+num.RR)>0){
 
           if(inherits(row.eff,"formula")){
-            lv.formula <- formula(paste("~", 0,paste("+", colnames(X[,-which(colnames(X)==all.vars(row.eff))]), collapse = "")))
+            lv.formula <- formula(paste("~", paste("+", colnames(X[,-which(colnames(X)==all.vars(row.eff))]), collapse = "")))
             if (is.data.frame(X)) {
-              datayx <- list(X = model.matrix(lv.formula, X))
+              datayx <- list(X = model.matrix(lv.formula, X)[,-1,drop=F])
             } else {
               datayx <- list(X = X)
             }
@@ -461,9 +461,9 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
             
             X <-  X[,all.vars(row.eff),drop=F]
           }else{
-            lv.formula <- formula(paste("~", 0,paste("+", colnames(X), collapse = "")))
+            lv.formula <- formula(paste("~", paste(colnames(X), collapse = "+")))
             if (is.data.frame(X)) {
-              datayx <- list(X = model.matrix(lv.formula, X))
+              datayx <- list(X = model.matrix(lv.formula, X)[,-1],drop=F)
             } else {
               datayx <- list(X = X)
             }
@@ -494,8 +494,8 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
             labterm<-labterm[labterm!=1&labterm!=0]
           }
 
-          lv.formula <- formula(paste("~", 0,paste("+", labterm, collapse = "")))
-          lv.X<- model.matrix(lv.formula,data=datayx)
+          lv.formula <- formula(paste("~", paste(labterm, collapse = "+")))
+          lv.X<- model.matrix(lv.formula,data=datayx)[,-1,drop=F]
      
         }else if(!is.null(formula)&!is.null(lv.formula)){
           datayx <- data.frame(y, X)
@@ -504,8 +504,8 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
           if(any(labterm==1)|any(labterm==0)){
             labterm<-labterm[labterm!=1&labterm!=0]
           }
-          lv.formula <- formula(paste("~", 0,paste("+", labterm, collapse = "")))
-          lv.X<- model.matrix(lv.formula,data=datayx)
+          lv.formula <- formula(paste("~", paste(labterm, collapse = "+")))
+          lv.X<- model.matrix(lv.formula,data=datayx)[,-1,drop=F]
           term <- terms(m1)
         }
 

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -1038,7 +1038,10 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, lv.formula = NUL
             }
             };
           if(quadratic!=FALSE){
-            if((num.lv+num.lv.c)>0)colnames(out$lvs) <-  c(paste("CLV", 1:num.lv.c, sep=""),paste("LV", 1:num.lv, sep=""));
+            if(num.lv.c>0&num.lv==0){colnames(out$lvs) <-  paste("CLV", 1:num.lv.c, sep="")
+            }else if(num.lv>0&num.lv.c==0){colnames(out$lvs) <- paste("LV", 1:num.lv, sep="")
+            }else if(num.lv>0&num.lv.c>0){coolnames(out$lvs) <- c(paste("CLV", 1:num.lv.c, sep=""),paste("LV", 1:num.lv, sep=""))}
+            
             colnames(out$params$theta)<- c(paste("CLV", 1:(num.lv.c+num.RR), sep=""),paste("LV", 1:num.lv, sep=""),paste("CLV", 1:(num.lv.c+num.RR), "^2",sep=""),paste("LV", 1:num.lv, "^2",sep=""));
           }
           rownames(out$params$theta) <- colnames(out$y)

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -99,7 +99,8 @@ start.values.gllvm.TMB <- function(y, X = NULL, lv.X = NULL, TR=NULL, family,
         } else {
           if(!is.null(X)) fit.mva <- mlm(y, X = X)
           if(is.null(X)) fit.mva <- mlm(y)
-          mu <- NULL
+
+          mu <- cbind(rep(1,nrow(y)),X) %*% fit.mva$coefficients
           # resi <- fit.mva$residuals; resi[is.infinite(resi)] <- 0; resi[is.nan(resi)] <- 0
           coef <- t(fit.mva$coef)
           fit.mva$phi <- apply(fit.mva$residuals,2,sd)

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -645,6 +645,7 @@ FAstart <- function(eta, family, y, num.lv = 0, num.lv.c = 0, num.RR = 0, zeta =
         if(family=="gaussian"&inherits(fa,"try-error")){
           fa <- princomp(resi)
           fa$scores <- fa$scores[,1:num.lv.c,drop=F]
+          fa$loadings <- fa$loadings[,1:num.lv.c,drop=F]
         }
         if(inherits(fa,"try-error")) stop("Calculating starting values failed. Try centering and scaling your predictors, a smaller 'num.lv.c' value, or change 'starting.val' to 'zero' or 'random'.")
         index <- fa$scores
@@ -652,10 +653,10 @@ FAstart <- function(eta, family, y, num.lv = 0, num.lv.c = 0, num.RR = 0, zeta =
         fa  <-  try(factanal(t(resi),factors=num.lv.c,scores = "regression"),silent=T)
         if(family=="gaussian"&inherits(fa,"try-error")){
           fa <- princomp(t(resi))
-          fa$loadings <- fa$loadings[,1:num.lv.c,drop=F]
+          fa$loadings <- fa$loadings[,1:num.lv.c, drop=F]
+          fa$scores <- fa$scores[,1:num.lv.c, drop=F]
         }
         if(inherits(fa,"try-error")) stop("Calculating starting values failed. Try centering and scaling your predictors, a smaller 'num.lv.c' value, or change 'starting.val' to 'zero' or 'random'.")
-        index <- matrix(fa$loadings,n,num.lv.c)
       } else {
         tryfit <- TRUE; tryi <- 1
         while(tryfit && tryi<5) {
@@ -665,7 +666,6 @@ FAstart <- function(eta, family, y, num.lv = 0, num.lv.c = 0, num.RR = 0, zeta =
         if(inherits(fa,"try-error")) {
           warning(attr(fa,"condition")$message, "\n Factor analysis for Calculating starting values failed. Try centering and scaling your predictors, a smaller 'num.lv.c' value, or change 'starting.val' to 'zero' or 'random'. Using solution from Principal Component Analysis instead. /n")
           fa <- princomp(resi)
-          index<-matrix(fa$scores[,1:num.lv.c],n,num.lv.c)
         }
       }
       if(n>p){
@@ -681,7 +681,6 @@ FAstart <- function(eta, family, y, num.lv = 0, num.lv.c = 0, num.RR = 0, zeta =
       
       #Ensures independence of LVs with predictors
       index <- matrix(residuals.lm(index.lm),ncol=num.lv.c)
-      
       colnames(gamma) <- paste("CLV",1:num.lv.c,sep='')
       
       if(num.lv.c>1 && p>2){

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -148,7 +148,8 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
     #A check if species scores are within the range of the LV
     ##If spp.arrows=TRUE plots those that are not in range as arrows
     if(spp.arrows){
-      idx <- choose.lv.coefs>matrix(apply(choose.lvs,2,min),ncol=ncol(choose.lv.coefs),nrow=nrow(choose.lv.coefs),byrow=T)&choose.lv.coefs<matrix(apply(choose.lvs,2,max),ncol=ncol(choose.lv.coefs),nrow=nrow(choose.lv.coefs),byrow=T)
+      lvth <- max(abs(choose.lvs))
+      idx <- choose.lv.coefs>(-lvth)&choose.lv.coefs<lvth
     }else{
       idx <- matrix(TRUE,ncol=num.lv+num.lv.c+num.RR,nrow=p)
     }

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -367,7 +367,7 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
       }
       
       #account for variance of the predictors
-      # LVcoef <- LVcoef/apply(object$lv.X,2,sd)
+      LVcoef <- LVcoef/apply(object$lv.X,2,sd)
       marg<-par("usr")
     
       origin<- c(mean(marg[1:2]),mean(marg[3:4]))

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -14,7 +14,7 @@
 #' @param cex.spp size of species labels in biplot
 #' @param cex.env size of labels for arrows in constrianed ordination
 #' @param spp.colors colors for sites, defaults to \code{"blue"}
-#' @param spp.arrows plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE}
+#' @param spp.arrows plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.
 #' @param lab.dist distance between label and arrow heads. Value between 0 and 1
 #' @param arrow.scale positive value, to scale arrows
 #' @param arrow.ci represent statistical uncertainty for arrows in constrained ordinatioon using confidence interval? Defaults to \code{TRUE}
@@ -83,10 +83,16 @@
 #'@export
 #'@export ordiplot.gllvm
 ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, main = NULL, which.lvs = c(1, 2), predict.region = FALSE, level =0.95,
-                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.ci = TRUE, spp.arrows = FALSE, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
+                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.ci = TRUE, spp.arrows = NULL, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
   if (!any(class(object) %in% "gllvm"))
     stop("Class of the object isn't 'gllvm'.")
-
+  if(is.null(spp.arrows)){
+    if(object$quadratic!=FALSE){
+      spp.arrows <- TRUE
+    }else{
+      spp.arrows <- FALSE
+    }
+  }
   arrow.scale <- abs(arrow.scale)
   a <- jitter.amount
   n <- NROW(object$y)

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -23,6 +23,7 @@
 #' @param lty.ellips line type for prediction ellipses. See graphical parameter lty.
 #' @param lwd.ellips line width for prediction ellipses. See graphical parameter lwd.
 #' @param col.ellips colors for prediction ellipses.
+#' @param principal rotate latent variables to principal direction"? Defaults to \code{TRUE}.
 #' @param ...	additional graphical arguments.
 #'
 #' @details
@@ -83,7 +84,7 @@
 #'@export
 #'@export ordiplot.gllvm
 ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, main = NULL, which.lvs = c(1, 2), predict.region = FALSE, level =0.95,
-                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.ci = TRUE, spp.arrows = FALSE, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1,...) {
+                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.ci = TRUE, spp.arrows = FALSE, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, principal = TRUE, ...) {
   if (!any(class(object) %in% "gllvm"))
     stop("Class of the object isn't 'gllvm'.")
 
@@ -126,8 +127,12 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
   
   if ((num.lv+(num.lv.c+num.RR)) > 1) {
     do_svd <- svd(lv)
+    if(principal){
     svd_rotmat_sites <- do_svd$v
     svd_rotmat_species <- do_svd$v
+    }else{
+      svd_rotmat_species <- svd_rotmat_sites <- diag(ncol(do_svd$v))
+    }
     
     choose.lvs <- lv
     if(quadratic == FALSE){choose.lv.coefs <- object$params$theta}else{choose.lv.coefs<-optima(object,sd.errors=F)}  
@@ -362,7 +367,7 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
       }
       
       #account for variance of the predictors
-      LVcoef <- LVcoef/apply(object$lv.X,2,sd)
+      # LVcoef <- LVcoef/apply(object$lv.X,2,sd)
       marg<-par("usr")
     
       origin<- c(mean(marg[1:2]),mean(marg[3:4]))

--- a/R/predict.gllvm.R
+++ b/R/predict.gllvm.R
@@ -181,7 +181,7 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
   
 
   if(level==1){
-  if(is.null(newLV) && !is.null(newdata)){ stop("Level 1 predictions cannot be calculated for new X values if new latent variable values are not given. Change to 'level = 0' predictions.")}
+  if(is.null(newLV) && !is.null(newdata) & nrow(newdata) != nrow(object$y)){ stop("Level 1 predictions cannot be calculated for new X values if new latent variable values are not given. Change to 'level = 0' predictions.")}
   
   if(object$num.lv > 0 |(object$num.lv.c+object$num.RR)>0) {
     
@@ -205,7 +205,7 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
       }
     }
 
-    if((object$num.lv.c+object$num.RR)>0&!is.null(newdata)){lv.X <-  as.matrix(model.frame(object$lv.formula,as.data.frame(newdata)))}else{lv.X<-object$lv.X}
+    if((object$num.lv.c+object$num.RR)>0&!is.null(newdata)){lv.X <-  model.matrix(object$lv.formula,as.data.frame(newdata))[,-1,drop=F]}else{lv.X<-object$lv.X}
     theta <- object$params$theta[,1:(object$num.lv+(object$num.lv.c+object$num.RR))]
       eta <- eta + lvs %*% t(theta)
       if((object$num.lv.c+object$num.RR)>0){

--- a/R/predict.gllvm.R
+++ b/R/predict.gllvm.R
@@ -64,7 +64,12 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
   n <- max(nrow(object$y),nrow(newdata), nrow(newLV))
   if(!is.null(newdata)) n <- nrow(newdata)
   # if(n!=nrow(object$y)&is.null(newLV)&(object$num.lv.c+object$num.lv)>0)stop("With new predictors with a different number of sites, new latent variables need to be provided through the newLV argument.")
-  if(is.null(newdata) && !is.null(object$X) && !is.null(newLV) && (nrow(newLV) != nrow(object$y))) stop("Number of rows in newLV must equal to the number of rows in the response matrix, if environmental variables are included in the model and newX is not included.") 
+  if(is.null(newdata) && !is.null(object$X) && !is.null(newLV)){
+    if(nrow(newLV) != nrow(object$y)){
+      stop("Number of rows in newLV must equal to the number of rows in the response matrix, if environmental variables are included in the model and newX is not included.")   
+    }
+    
+  } 
   if(!is.null(object$X)){formula <- formula(terms(object))}else{formula<-NULL}
   
   if(object$row.eff != FALSE) {
@@ -181,7 +186,12 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
   
 
   if(level==1){
-  if(is.null(newLV) && !is.null(newdata) & nrow(newdata) != nrow(object$y)){ stop("Level 1 predictions cannot be calculated for new X values if new latent variable values are not given. Change to 'level = 0' predictions.")}
+  if(is.null(newLV) && !is.null(newdata)){ 
+    if(nrow(newdata) != nrow(object$y)) {
+      
+      stop("Level 1 predictions cannot be calculated for new X values if new latent variable values are not given. Change to 'level = 0' predictions.")
+    }
+  }
   
   if(object$num.lv > 0 |(object$num.lv.c+object$num.RR)>0) {
     

--- a/R/residuals.gllvm.R
+++ b/R/residuals.gllvm.R
@@ -94,7 +94,7 @@ residuals.gllvm <- function(object, ...) {
   eta.mat <- eta.mat  + lvs %*% t(object$params$theta[,1:(num.lv+num.lv.c+num.RR),drop=F])
   }
   if(quadratic != FALSE){
-   eta.mat <- eta.mat  + lvs^2 %*% t(object$params$theta[,-c(1:(num.lv+num.lv.c)),drop=F])
+   eta.mat <- eta.mat  + lvs^2 %*% t(object$params$theta[,-c(1:(num.lv+num.lv.c+num.RR)),drop=F])
   }
   
   if (!is.null(object$randomX))

--- a/R/summary.gllvm.R
+++ b/R/summary.gllvm.R
@@ -100,6 +100,8 @@ summary.gllvm <- function(object, digits = max(3L, getOption("digits") - 3L),
     pvalue <- 2 * pnorm(-abs(zval))
     coef.table <- cbind(pars, se, zval, pvalue)
     dimnames(coef.table) <- list(newnam, c("Estimate", "Std. Error", "z value", "Pr(>|z|)"))
+  }else{
+    coef.table <- NULL
   }
   
   if (!is.logical(object$sd)&!is.null(object$lv.X)) {
@@ -110,6 +112,8 @@ summary.gllvm <- function(object, digits = max(3L, getOption("digits") - 3L),
     pvalue <- 2 * pnorm(-abs(zval))
     coef.table.constrained <- cbind(pars, se, zval, pvalue)
     dimnames(coef.table.constrained) <- list(paste(rep(colnames(object$lv.X),2),"(LV",rep(1:(object$num.lv.c+object$num.RR),each=ncol(object$lv.X)),")",sep=""), c("Estimate", "Std. Error", "z value", "Pr(>|z|)"))
+  }else{
+    coef.table.constrained <- NULL
   }
     
   colnames(M) <- newnams
@@ -159,7 +163,7 @@ summary.gllvm <- function(object, digits = max(3L, getOption("digits") - 3L),
     sumry$sigma.lv <- object$params$sigma.lv
   }
   
-  if((object$num.lv.c+object$num.RR)>0){
+  if((object$num.lv.c+object$num.RR)>0&!is.null(coef.table.constrained)){
     sumry$'Coef.tableLV' <- coef.table.constrained
   }
   class(sumry) <- "summary.gllvm"


### PR DESCRIPTION
- num.lv was not set to zero by default if num.RR was used
- bugfix for num.RR + num.lv
- added option to turn off the default rotation of LVs to principal direction in ordiplot
- Formula interface for constrained model wasn't correctly handling factor predictors due to omitting the intercept. Now, the intercept is first included but the first column of the design matrix is removed (otherwise the categories of a factor are all included as separate predictors), so this should be better.