### PR TITLE
Grouped dispersion parameters

### DIFF
--- a/R/TMBtrait.R
+++ b/R/TMBtrait.R
@@ -476,7 +476,7 @@ trait.TMB <- function(
     
     map.list <- list()    
     #    if(row.eff==FALSE) map.list$r0 <- factor(rep(NA,n))
-    if(family %in% c("poisson","binomial","ordinal","exponential")) map.list$lg_phi <- factor(rep(NA,length(disp.group)))
+    if(family %in% c("poisson","binomial","ordinal","exponential")) map.list$lg_phi <- factor(rep(NA,length(unique(disp.group))))
     if(family != "ordinal") map.list$zeta <- factor(NA)
     
   ### family settings

--- a/R/TMBtrait.R
+++ b/R/TMBtrait.R
@@ -582,7 +582,7 @@ trait.TMB <- function(
 
       parameter.list = list(r0=matrix(r0), b = rbind(a), b_lv = matrix(0), B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta)
       objr <- TMB::MakeADFun(
-        data = list(y = y, x = Xd,x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, family=familyn, extra=extra, quadratic = 1, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group), silent=!trace,
+        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, family=familyn, extra=extra, quadratic = 1, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group), silent=!trace,
         parameters = parameter.list, map = map.list2,
         inner.control=list(mgcmax = 1e+200,maxit = maxit),
         DLL = "gllvm")
@@ -607,7 +607,7 @@ trait.TMB <- function(
     if((method %in% c("VA", "EVA")) && (num.lv>0 || row.eff=="random" || !is.null(randomX))){
       parameter.list = list(r0=matrix(r0), b = rbind(a), b_lv = matrix(0), B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta)
       objr <- TMB::MakeADFun(
-        data = list(y = y, x = Xd,x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group), silent=!trace,
+        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group), silent=!trace,
         parameters = parameter.list, map = map.list,
         inner.control=list(mgcmax = 1e+200,maxit = maxit),
         DLL = "gllvm")
@@ -615,7 +615,7 @@ trait.TMB <- function(
       Au=0; Abb=0; lg_Ar=0;
       map.list$Au <- map.list$Abb <- map.list$lg_Ar <- factor(NA)
       parameter.list = list(r0=matrix(r0), b = rbind(a), b_lv = matrix(0), B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta)
-      data.list <- list(y = y, x = Xd,x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 0, family=familyn,extra=extra,method=1,model=1,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
+      data.list <- list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 0, family=familyn,extra=extra,method=1,model=1,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
       if(family == "ordinal"){
         data.list$method = 0
       }
@@ -687,7 +687,7 @@ trait.TMB <- function(
       
       parameter.list = list(r0=r1, b = b1, b_lv = matrix(0), B=B1, Br=Br1, lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1, lg_phi=lg_phi1, sigmaB=sigmaB1, sigmaij=sigmaij1, log_sigma=lg_sigma1, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta)
 
-      data.list = list(y = y, x = Xd,x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = ifelse(quadratic!=FALSE&num.lv>0,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
+      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = ifelse(quadratic!=FALSE&num.lv>0,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
       objr <- TMB::MakeADFun(
         data = data.list, silent=!trace,
         parameters = parameter.list, map = map.list,
@@ -744,7 +744,7 @@ trait.TMB <- function(
       
       parameter.list = list(r0=r1, b = b1, b_lv = matrix(0), B=B1, Br=Br1, lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1, lg_phi=lg_phi1, sigmaB=sigmaB1, sigmaij=sigmaij1, log_sigma=lg_sigma1, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta)
 
-      data.list = list(y = y, x = Xd,x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 1, family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
+      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 1, family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, disp_group = disp.group)
       objr <- TMB::MakeADFun(
         data = data.list, silent=!trace,
         parameters = parameter.list, map = map.list,

--- a/R/TMBtrait.R
+++ b/R/TMBtrait.R
@@ -10,7 +10,7 @@ trait.TMB <- function(
       link="logit",n.init=1,start.params=NULL,start0=FALSE,optimizer="optim", dr=NULL, rstruc =0, cstruc = "diag", dist = matrix(0),
       starting.val="res",method="VA",randomX=NULL,Power=1.5,diag.iter=1, Ab.diag.iter = 0, dependent.row = FALSE,
       Lambda.start=c(0.2, 0.5), jitter.var=0, yXT = NULL, scale.X = FALSE, randomX.start = "zero", beta0com = FALSE
-      ,zeta.struc = "species", quad.start=0.01, start.struc="LV",quadratic=FALSE, optim.method = "BFGS") {
+      ,zeta.struc = "species", quad.start=0.01, start.struc="LV",quadratic=FALSE, optim.method = "BFGS", disp.group = NULL) {
   if(is.null(X) && !is.null(TR)) stop("Unable to fit a model that includes only trait covariates")
   if(!is.null(start.params)) starting.val <- "zero"
   
@@ -242,7 +242,7 @@ trait.TMB <- function(
     #### Calculate starting values
 
     res <- start.values.gllvm.TMB(y = y, X = X1, TR = TR1, family = family, offset=offset, trial.size = trial.size, num.lv = num.lv, start.lvs = start.lvs, seed = seed[n.i],starting.val=starting.val,Power=Power,formula = formula, jitter.var=jitter.var, #!!!
-                                  yXT=yXT, row.eff = row.eff, TMB=TRUE, link=link, randomX=randomXb, beta0com = beta0com0, zeta.struc = zeta.struc)
+                                  yXT=yXT, row.eff = row.eff, TMB=TRUE, link=link, randomX=randomXb, beta0com = beta0com0, zeta.struc = zeta.struc, disp.group = disp.group)
 
     ## Set initial values
     

--- a/R/confint.gllvm.R
+++ b/R/confint.gllvm.R
@@ -154,25 +154,25 @@ confint.gllvm <- function(object, parm=NULL, level = 0.95, ...) {
       cal <- cal + length(object$params$sigmaB)
     }
     if(object$family == "negative.binomial"){
-      s <- dim(M)[1]
-      rnames[(cal + 1):s] <- paste("inv.phi", names(object$params$beta0), sep = ".")
+      s <- length(unique(object$disp.group))
+      rnames[(cal + 1):(s+cal)] <- paste("inv.phi", names(object$params$inv.phi), sep = ".")
     }
     
     if(object$family == "tweedie"){
-      s <- dim(M)[1]
-      rnames[(cal + 1):s] <- paste("Dispersion phi", names(object$params$phi), sep = ".")
+      s <-length(unique(object$disp.group))
+      rnames[(cal + 1):(s+cal)] <- paste("Dispersion phi", names(object$params$phi), sep = ".")
     }
     if(object$family == "ZIP"){
-      s <- dim(M)[1]
-      rnames[(cal + 1):s] <- paste("p", names(object$params$p), sep = ".")
+      s <- length(unique(object$disp.group))
+      rnames[(cal + 1):(s+cal)] <- paste("p", names(object$params$p), sep = ".")
     }
     if(object$family == "gaussian"){
-      s <- dim(M)[1]
-      rnames[(cal + 1):s] <- paste("Standard deviations phi", names(object$params$phi), sep = ".")
+      s <- length(unique(object$disp.group))
+      rnames[(cal + 1):(s+cal)] <- paste("Standard deviations phi", names(object$params$phi), sep = ".")
     }
     if(object$family == "gamma"){
-      s <- dim(M)[1]
-      rnames[(cal + 1):s] <- paste("Shape phi", names(object$params$phi), sep = ".")
+      s <- length(unique(object$disp.group))
+      rnames[(cal + 1):(s+cal)] <- paste("Shape phi", names(object$params$phi), sep = ".")
     }
     rownames(M) <- rnames
   } else {

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -828,8 +828,8 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, lv
       if(length(disp.group)!=p){
         stop("disp.group must be a vector of same length as the number of species.")
       }
-      if(diff(unique(sort(disp.group)))!=1){
-        stop("disp.group indices must be a sequence without gaps.")
+      if(any(diff(unique(sort(disp.group)))!=1)){
+        stop("disp.group indices must form a sequence without gaps.")
       }
       if(min(disp.group)!=1&max(disp.group)!=length(unique(disp.group))){
         stop("disp.group must start at 1 and end at length(unique(disp.group)).")

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -30,7 +30,7 @@
 #' @param scale.X if \code{TRUE}, covariates are scaled when fourth corner model is fitted.
 #' @param return.terms logical, if \code{TRUE} 'terms' object is returned.
 #' @param gradient.check logical, if \code{TRUE} gradients are checked for large values (>0.01) even if the optimization algorithm did converge.
-#' @param disp.group vector of indices that dispersion parameters (in e.g., a negative-binomial distribution) should be assumed the same for. Defaults to NULL so that all species have their own dispersion parameter.
+#' @param disp.group vector of indices for the grouping of dispersion parameters (in e.g., a negative-binomial distribution). Defaults to NULL so that all species have their own dispersion parameter.
 #' @param control A list with the following arguments controlling the optimization:
 #' \itemize{
 #'  \item{\emph{reltol}: }{ convergence criteria for log-likelihood, defaults to 1e-8.}

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -487,7 +487,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, lv.formula = NUL
         map.list2$Br = factor(rep(NA,length(Br)))
         #map.list2$lambda = factor(rep(NA, length(lambda)))
         map.list2$u = factor(rep(NA, length(u)))
-        map.list2$lg_phi = factor(rep(NA, length(phi)))
+        map.list2$lg_phi = factor(rep(NA, length(unique(disp.group))))
         map.list2$log_sigma = factor(rep(NA, length(sigma)))
         map.list2$sigmaB = factor(rep(NA,length(sigmaB)))
         map.list2$sigmaij = factor(rep(NA,length(sigmaij)))

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -851,8 +851,10 @@ FAstart <- function(eta, family, y, num.lv = 0, num.lv.c = 0, num.RR = 0, zeta =
     #Alternative for RRcoef is factor analysis of the predictors.
     RRmod <- lm(resi~0+lv.X)
     beta <- t(coef(RRmod))
+    if(ncol(beta)>1){
     betaSD=apply(beta,1,sd)
     beta=beta/betaSD
+    }
     qr.beta=qr(t(beta))
     R=t(qr.R(qr.beta))
     R=R[,1:num.RR,drop=F]/sqrt(num.RR*nrow(RRmod$coefficients))

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -175,7 +175,7 @@ start.values.gllvm.TMB <- function(y, X = NULL, lv.X = NULL, TR=NULL, family,
         
         gamma=NULL
         if((num.lv+num.lv.c+num.RR)>0){
-          lastart <- FAstart(eta=mu, family=family, y=y, num.lv = num.lv, num.lv.c = num.lv.c, phis=fit.mva$phi, lv.X = lv.X, link = link, maxit=maxit,max.iter=max.iter)
+          lastart <- FAstart(eta=mu, family=family, y=y, num.lv = num.lv, num.lv.c = num.lv.c, phis=fit.mva$phi, lv.X = lv.X, link = link, maxit=maxit,max.iter=max.iter, disp.group = disp.group)
           gamma<-lastart$gamma
           index<-lastart$index
           if(num.lv.c>0)
@@ -353,7 +353,7 @@ start.values.gllvm.TMB <- function(y, X = NULL, lv.X = NULL, TR=NULL, family,
       if(!is.null(X) && is.null(TR)) eta.mat <- eta.mat + (X %*% matrix(params[,2:(1+num.X)],num.X,p))
       mu <- eta.mat
       if((num.lv+num.lv.c+num.RR)>0){
-        lastart <- FAstart(eta.mat, family=family, y=y, num.lv = num.lv, num.lv.c = num.lv.c, num.RR= num.RR, zeta = zeta, zeta.struc = zeta.struc, lv.X = lv.X, link = link, maxit=maxit,max.iter=max.iter)
+        lastart <- FAstart(eta.mat, family=family, y=y, num.lv = num.lv, num.lv.c = num.lv.c, num.RR= num.RR, zeta = zeta, zeta.struc = zeta.struc, lv.X = lv.X, link = link, maxit=maxit,max.iter=max.iter, disp.group = disp.group)
         gamma<-lastart$gamma
         index<-lastart$index
         params[,(ncol(cbind(1,X))+1):ncol(params)]=gamma

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -17,6 +17,7 @@
 #' @param spp.arrows plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.
 #' @param lab.dist distance between label and arrow heads. Value between 0 and 1
 #' @param arrow.scale positive value, to scale arrows
+#' @param arrow.spp.scale positive value, to scale arrows of species
 #' @param arrow.ci represent statistical uncertainty for arrows in constrained ordinatioon using confidence interval? Defaults to \code{TRUE}
 #' @param predict.region logical, if \code{TRUE} prediction regions for the predicted latent variables are plotted, defaults to \code{FALSE}.
 #' @param level level for prediction regions.
@@ -83,7 +84,7 @@
 #'@export
 #'@export ordiplot.gllvm
 ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, main = NULL, which.lvs = c(1, 2), predict.region = FALSE, level =0.95,
-                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.ci = TRUE, spp.arrows = NULL, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
+                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.spp.scale = 0.8, arrow.ci = TRUE, spp.arrows = NULL, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
   if (!any(class(object) %in% "gllvm"))
     stop("Class of the object isn't 'gllvm'.")
   if(is.null(spp.arrows)){
@@ -294,12 +295,11 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         } else {
           text(choose.lvs[, which.lvs], label = 1:n, cex = 1.2, col = s.colors)
         }
-        
-        spp.colors <- spp.colors[largest.lnorms][1:ind.spp]
+
         text(
-          matrix(choose.lv.coefs[largest.lnorms[1:ind.spp],which.lvs][apply(idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)all(x)),], nrow = sum(apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x)))),
-          label = rownames(object$params$theta)[largest.lnorms[1:ind.spp]][apply(idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)all(x))],
-          col = spp.colors, cex = cex.spp )
+          matrix(choose.lv.coefs[largest.lnorms[1:ind.spp],which.lvs,drop=F][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x)),], nrow = sum(apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x)))),
+          label = rownames(object$params$theta)[largest.lnorms[1:ind.spp]][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))],
+          col = spp.colors[largest.lnorms][1:ind.spp][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))], cex = cex.spp )
       }
       if (jitter){
         if (symbols) {
@@ -311,11 +311,10 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
             (choose.lvs[, which.lvs[2]] + runif(n,-a,a)),
             label = 1:n, cex = 1.2, col = s.colors )
         }
-        spp.colors <- spp.colors[apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x))]
         text(
-          (matrix(choose.lv.coefs[largest.lnorms,which.lvs][apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x)),], nrow =sum(apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x)))) + runif(2*sum(apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x))),-a,a)),
-          label = rownames(object$params$theta)[largest.lnorms][apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x))],
-          col = spp.colors, cex = cex.spp )
+          matrix(choose.lv.coefs[largest.lnorms[1:ind.spp],which.lvs,drop=F][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x)),], nrow = sum(apply(!idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!any(x)))),
+          label = rownames(object$params$theta)[largest.lnorms[1:ind.spp]][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))],
+          col = spp.colors[largest.lnorms][1:ind.spp][apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))], cex = cex.spp )
       }
       
       ##Here add arrows for species with optima outside of range LV
@@ -328,10 +327,10 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         #scores_to_plot <- choose.lv.coefs[largest.lnorms[!apply(idx[largest.lnorms,which.lvs,drop=F],1,all)],which.lvs,drop=F]
         scores_to_plot <- choose.lv.coefs[largest.lnorms[1:ind.spp],which.lvs][apply(idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!all(x)),,drop=F]
         if(nrow(scores_to_plot)>0){
-          ends <- t(t(t(t(scores_to_plot)-origin)/sqrt((scores_to_plot[,1]-origin[1])^2+(scores_to_plot[,2]-origin[2])^2)*min(Xlength,Ylength)))
+          ends <- t(t(t(t(scores_to_plot)-origin)/sqrt((scores_to_plot[,1]-origin[1])^2+(scores_to_plot[,2]-origin[2])^2)*min(Xlength,Ylength)))*arrow.spp.scale
           for(i in 1:nrow(scores_to_plot)){
-            arrows(origin[1],origin[2],ends[i,1]+origin[1],ends[i,2]+origin[2],col=spp.colors[i], cex = cex.spp, length = 0.2)
-            text(x=ends[i,1]*(1+lab.dist)+origin[1],y=ends[i,2]*(1+lab.dist)+origin[2],labels = row.names(scores_to_plot)[i],col=spp.colors[i], cex = cex.spp)
+            arrows(origin[1],origin[2],ends[i,1]+origin[1],ends[i,2]+origin[2],col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))][i], cex = cex.spp, length = 0.2)
+            text(x=ends[i,1]*(1+lab.dist)+origin[1],y=ends[i,2]*(1+lab.dist)+origin[2],labels = row.names(scores_to_plot)[i],col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))][i], cex = cex.spp)
           }
         }
         # }

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -129,8 +129,22 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
   lv <- getLV(object, type = type)
   
   if ((num.lv+(num.lv.c+num.RR)) == 1) {
-    if(num.lv==1)plot(1:n, lv, ylab = "LV1", xlab = "Row index")
-    if((num.lv.c+num.RR)==1)plot(1:n, lv, ylab = "CLV1", xlab = "Row index")
+    if(num.lv==1){
+      plot(1:n, lv, ylab = "LV1", xlab = "Row index", type="n") 
+      if (symbols) {
+        points(lv, col = s.colors, ...)
+      } else {
+        text(lv, label = 1:n, cex = 1.2, col = s.colors)
+      }
+    }
+    if((num.lv.c+num.RR)==1){
+      plot(1:n, lv, ylab = "CLV1", xlab = "Row index", type="n") 
+      if (symbols) {
+        points(lv, col = s.colors, ...)
+      } else {
+        text(lv, label = 1:n, cex = 1.2, col = s.colors)
+      }
+    }    
   }
   
   if ((num.lv+(num.lv.c+num.RR)) > 1) {

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -14,11 +14,13 @@
 #' @param cex.spp size of species labels in biplot
 #' @param cex.env size of labels for arrows in constrianed ordination
 #' @param spp.colors colors for sites, defaults to \code{"blue"}
-#' @param spp.arrows plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.
+#' @param spp.arrow plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.
+#' @param spp.arrow.lty linetype for species arrows
 #' @param lab.dist distance between label and arrow heads. Value between 0 and 1
 #' @param arrow.scale positive value, to scale arrows
 #' @param arrow.spp.scale positive value, to scale arrows of species
 #' @param arrow.ci represent statistical uncertainty for arrows in constrained ordinatioon using confidence interval? Defaults to \code{TRUE}
+#' @param arrow.lty linetype for arrows in constrained
 #' @param predict.region logical, if \code{TRUE} prediction regions for the predicted latent variables are plotted, defaults to \code{FALSE}.
 #' @param level level for prediction regions.
 #' @param lty.ellips line type for prediction ellipses. See graphical parameter lty.
@@ -84,7 +86,7 @@
 #'@export
 #'@export ordiplot.gllvm
 ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, main = NULL, which.lvs = c(1, 2), predict.region = FALSE, level =0.95,
-                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.spp.scale = 0.8, arrow.ci = TRUE, spp.arrows = NULL, cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
+                           jitter = FALSE, jitter.amount = 0.2, s.colors = 1, symbols = FALSE, cex.spp = 0.7, spp.colors = "blue", arrow.scale = 0.8, arrow.spp.scale = 0.8, arrow.ci = TRUE, arrow.lty = "solid", spp.arrows = NULL, spp.arrow.lty = "dashed", cex.env = 0.7, lab.dist = 0.1, lwd.ellips = 0.5, col.ellips = 4, lty.ellips = 1, ...) {
   if (!any(class(object) %in% "gllvm"))
     stop("Class of the object isn't 'gllvm'.")
   if(is.null(spp.arrows)){
@@ -328,10 +330,8 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         scores_to_plot <- choose.lv.coefs[largest.lnorms[1:ind.spp],which.lvs][apply(idx[largest.lnorms[1:ind.spp],which.lvs],1,function(x)!all(x)),,drop=F]
         if(nrow(scores_to_plot)>0){
           ends <- t(t(t(t(scores_to_plot)-origin)/sqrt((scores_to_plot[,1]-origin[1])^2+(scores_to_plot[,2]-origin[2])^2)*min(Xlength,Ylength)))*arrow.spp.scale
-          for(i in 1:nrow(scores_to_plot)){
-            arrows(origin[1],origin[2],ends[i,1]+origin[1],ends[i,2]+origin[2],col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))][i], cex = cex.spp, length = 0.2)
-            text(x=ends[i,1]*(1+lab.dist)+origin[1],y=ends[i,2]*(1+lab.dist)+origin[2],labels = row.names(scores_to_plot)[i],col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))][i], cex = cex.spp)
-          }
+            arrows(origin[1],origin[2],ends[,1]+origin[1],ends[,2]+origin[2],col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))], cex = cex.spp, length = 0.2, lty=spp.arrow.lty)
+            text(x=ends[,1]*(1+lab.dist)+origin[1],y=ends[,2]*(1+lab.dist)+origin[2],labels = row.names(scores_to_plot),col=spp.colors[largest.lnorms][1:ind.spp][!apply(idx[largest.lnorms[1:ind.spp],which.lvs,drop=F],1,function(x)all(x))], cex = cex.spp)
         }
         # }
       }
@@ -354,7 +354,7 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         rotSD <- rotSD[,which.lvs]
         cilow <- LVcoef+qnorm( (1 - 0.95) / 2)*rotSD
         ciup <-LVcoef+qnorm(1- (1 - 0.95) / 2)*rotSD
-        lty <- rep("solid",ncol(object$lv.X))
+        lty <- rep(arrow.lty,ncol(object$lv.X))
         col <- rep("red", ncol(object$lv.X))
         lty[sign(cilow[,1])!=sign(ciup[,1])|sign(cilow[,2])!=sign(ciup[,2])] <- "solid"
         col[sign(cilow[,1])!=sign(ciup[,1])|sign(cilow[,2])!=sign(ciup[,2])] <- hcl(0, 100, 80)#rgb(1,0,0,alpha=0.3)

--- a/R/residuals.gllvm.R
+++ b/R/residuals.gllvm.R
@@ -124,8 +124,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "negative.binomial") {
         phis <- object$params$phi + 1e-05
-        a <- pnbinom(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], size = 1 / phis[j])
-        b <- pnbinom(as.vector(unlist(y[i, j])), mu = mu[i, j], size = 1 / phis[j])
+        a <- pnbinom(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], size = 1 / phis[object$disp.group[j]])
+        b <- pnbinom(as.vector(unlist(y[i, j])), mu = mu[i, j], size = 1 / phis[object$disp.group[j]])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -133,8 +133,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "gaussian") {
         phis <- object$params$phi
-        a <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[j])
-        b <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[j])
+        a <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[object$disp.group[j]])
+        b <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[object$disp.group[j]])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -142,8 +142,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "gamma") {
         phis <- object$params$phi # - 1
-        a <- pgamma(as.vector(unlist(y[i, j])), shape = phis[j], scale = mu[i, j]/phis[j])
-        b <- pgamma(as.vector(unlist(y[i, j])), shape = phis[j], scale = mu[i, j]/phis[j])
+        a <- pgamma(as.vector(unlist(y[i, j])), shape = phis[object$disp.group[j]], scale = mu[i, j]/phis[object$disp.group[j]])
+        b <- pgamma(as.vector(unlist(y[i, j])), shape = phis[object$disp.group[j]], scale = mu[i, j]/phis[object$disp.group[j]])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -184,10 +184,10 @@ residuals.gllvm <- function(object, ...) {
 
       if (object$family == "tweedie") {
         phis <- object$params$phi + 1e-05
-        a <- fishMod::pTweedie(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], phi = phis[j], p = object$Power);
+        a <- fishMod::pTweedie(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], phi = phis[object$disp.group[j]], p = object$Power);
         if((as.vector(unlist(y[i, j])) - 1)<0)
           a<-0
-        b <- fishMod::pTweedie(as.vector(unlist(y[i, j])), mu = mu[i, j], phi = phis[j], p = object$Power)
+        b <- fishMod::pTweedie(as.vector(unlist(y[i, j])), mu = mu[i, j], phi = phis[object$disp.group[j]], p = object$Power)
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16

--- a/R/residuals.gllvm.R
+++ b/R/residuals.gllvm.R
@@ -124,8 +124,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "negative.binomial") {
         phis <- object$params$phi + 1e-05
-        a <- pnbinom(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], size = 1 / phis[object$disp.group[j]])
-        b <- pnbinom(as.vector(unlist(y[i, j])), mu = mu[i, j], size = 1 / phis[object$disp.group[j]])
+        a <- pnbinom(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], size = 1 / phis[j])
+        b <- pnbinom(as.vector(unlist(y[i, j])), mu = mu[i, j], size = 1 / phis[j])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -133,8 +133,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "gaussian") {
         phis <- object$params$phi
-        a <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[object$disp.group[j]])
-        b <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[object$disp.group[j]])
+        a <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[j])
+        b <- pnorm(as.vector(unlist(y[i, j])), mu[i, j], sd = phis[j])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -142,8 +142,8 @@ residuals.gllvm <- function(object, ...) {
       }
       if (object$family == "gamma") {
         phis <- object$params$phi # - 1
-        a <- pgamma(as.vector(unlist(y[i, j])), shape = phis[object$disp.group[j]], scale = mu[i, j]/phis[object$disp.group[j]])
-        b <- pgamma(as.vector(unlist(y[i, j])), shape = phis[object$disp.group[j]], scale = mu[i, j]/phis[object$disp.group[j]])
+        a <- pgamma(as.vector(unlist(y[i, j])), shape = phis[j], scale = mu[i, j]/phis[j])
+        b <- pgamma(as.vector(unlist(y[i, j])), shape = phis[j], scale = mu[i, j]/phis[j])
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16
@@ -184,10 +184,10 @@ residuals.gllvm <- function(object, ...) {
 
       if (object$family == "tweedie") {
         phis <- object$params$phi + 1e-05
-        a <- fishMod::pTweedie(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], phi = phis[object$disp.group[j]], p = object$Power);
+        a <- fishMod::pTweedie(as.vector(unlist(y[i, j])) - 1, mu = mu[i, j], phi = phis[j], p = object$Power);
         if((as.vector(unlist(y[i, j])) - 1)<0)
           a<-0
-        b <- fishMod::pTweedie(as.vector(unlist(y[i, j])), mu = mu[i, j], phi = phis[object$disp.group[j]], p = object$Power)
+        b <- fishMod::pTweedie(as.vector(unlist(y[i, j])), mu = mu[i, j], phi = phis[j], p = object$Power)
         u <- runif(n = 1, min = a, max = b)
         if(u==1) u=1-1e-16
         if(u==0) u=1e-16

--- a/R/se.gllvm.R
+++ b/R/se.gllvm.R
@@ -42,6 +42,7 @@ se.gllvm <- function(object, ...){
   rstruc = object$rstruc
   family = object$family
   familyn <- objrFinal$env$data$family
+  disp.group <- object$disp.group
   out <- list()
   if (!is.null(object$TR)) {
     {
@@ -166,7 +167,7 @@ se.gllvm <- function(object, ...){
           out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
         }
         out$sd$sigma.lv  <- se.sigma.lv
-        names(out$sd$sigma.lv) <- colnames(out$params$theta[,1:num.lv])
+        names(out$sd$sigma.lv) <- colnames(object$params$theta[,1:num.lv])
       }
 
       out$sd$beta0 <- se.beta0; 
@@ -175,20 +176,43 @@ se.gllvm <- function(object, ...){
       if(object$row.eff=="fixed") {out$sd$row.params <- se.row.params}
       
       if(family %in% c("negative.binomial")) {
-        se.lphis <- se[1:p];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
+        se.lphis <- se[1:length(unique(disp.group))];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
         out$sd$phi <- se.lphis*object$params$phi;
-        names(out$sd$inv.phi) <- names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+        if(length(unique(disp.group))==p){
+          names(out$sd$phi) <- colnames(y);
+        }else if(!is.null(names(disp.group))){
+          try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+        }else{
+          names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+        }
+        names(out$sd$inv.phi) <-  names(out$sd$phi)
+        se <- se[-(1:length(unique(disp.group)))]
       }
       if(family %in% c("gaussian","tweedie","gamma", "beta")) {
-        se.lphis <- se[1:p];
+        se.lphis <- se[1:length(unique(disp.group))];
         out$sd$phi <- se.lphis*object$params$phi;
-        names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+        if(length(unique(disp.group))==p){
+          names(out$sd$phi) <- colnames(y);
+        }else if(!is.null(names(disp.group))){
+          try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+        }else{
+          names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+        }
+        
+        se <- se[-(1:length(unique(disp.group)))]
       }
       if(family %in% c("ZIP")) {
-        lp0 <- objrFinal$par[names(objrFinal$par)=="lg_phi"]
-        se.phis <- se[1:p];
+        se.phis <- se[1:length(unique(disp.group))];
         out$sd$phi <- se.phis*exp(lp0)/(1+exp(lp0))^2;#
-        names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+        if(length(unique(disp.group))==p){
+          names(out$sd$phi) <- colnames(y);
+        }else if(!is.null(names(disp.group))){
+          try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+        }else{
+          names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+        }
+        names(out$sd$inv.phi) <-  names(out$sd$phi)
+        se <- se[-(1:length(unique(disp.group)))]
       }
       if(!is.null(object$randomX)){
         nr <- ncol(xb)
@@ -402,7 +426,7 @@ se.gllvm <- function(object, ...){
     }
     if((num.lv+num.lv.c)>0){
       out$sd$sigma.lv  <- se.sigma.lv
-      names(out$sd$sigma.lv) <- colnames(out$params$theta[,1:(num.lv+num.lv.c)])
+      names(out$sd$sigma.lv) <- colnames(object$params$theta[,1:(num.lv+num.lv.c)])
     }
     
     out$sd$beta0 <- sebetaM[,1]; names(out$sd$beta0) <- colnames(object$y);
@@ -413,20 +437,43 @@ se.gllvm <- function(object, ...){
     if(object$row.eff=="fixed") {out$sd$row.params <- se.row.params}
     
     if(family %in% c("negative.binomial")) {
-      se.lphis <- se[1:p];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
+      se.lphis <- se[1:length(unique(disp.group))];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
       out$sd$phi <- se.lphis*object$params$phi;
-      names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+      if(length(unique(disp.group))==p){
+        names(out$sd$phi) <- colnames(y);
+      }else if(!is.null(names(disp.group))){
+        try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+      }else{
+        names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+      }
+      names(out$sd$inv.phi) <-  names(out$sd$phi)
+      se <- se[-(1:length(unique(disp.group)))]
     }
-    if(family %in% c("tweedie", "gaussian", "gamma","beta")) {
-      se.lphis <- se[1:p];
+    if(family %in% c("gaussian","tweedie","gamma", "beta")) {
+      se.lphis <- se[1:length(unique(disp.group))];
       out$sd$phi <- se.lphis*object$params$phi;
-      names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+      if(length(unique(disp.group))==p){
+        names(out$sd$phi) <- colnames(y);
+      }else if(!is.null(names(disp.group))){
+        try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+      }else{
+        names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+      }
+      
+      se <- se[-(1:length(unique(disp.group)))]
     }
     if(family %in% c("ZIP")) {
-      lp0 <- objrFinal$par[names(objrFinal$par)=="lg_phi"]
-      se.phis <- se[1:p];
+      se.phis <- se[1:length(unique(disp.group))];
       out$sd$phi <- se.phis*exp(lp0)/(1+exp(lp0))^2;#
-      names(out$sd$phi) <- colnames(object$y);  se <- se[-(1:p)]
+      if(length(unique(disp.group))==p){
+        names(out$sd$phi) <- colnames(y);
+      }else if(!is.null(names(disp.group))){
+        try(names(out$sd$phi) <- unique(names(disp.group)),silent=T)
+      }else{
+        names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
+      }
+      names(out$sd$inv.phi) <-  names(out$sd$phi)
+      se <- se[-(1:length(unique(disp.group)))]
     }
     if(object$row.eff=="random") { 
       out$sd$sigma <- se[1:length(object$params$sigma)]*c(object$params$sigma[1],rep(1,length(object$params$sigma)-1)); 

--- a/R/summary.gllvm.R
+++ b/R/summary.gllvm.R
@@ -56,11 +56,16 @@ summary.gllvm <- function(object, digits = max(3L, getOption("digits") - 3L),
   }else{
     svd_rotmat_sites <- diag(num.lv.c+num.RR+num.lv)
   }
-  if(quadratic==FALSE){
-    M <- cbind(object$params$beta0, object$params$theta[,1:(num.lv.c+num.RR+num.lv)]%*%svd_rotmat_sites)  
+  if(num.lv|num.lv.c|num.RR>0){
+    if(quadratic==FALSE){
+      M <- cbind(object$params$beta0, object$params$theta[,1:(num.lv.c+num.RR+num.lv)]%*%svd_rotmat_sites)  
+    }else{
+      M <- cbind(object$params$beta0, optima(object,sd.errors=F)%*%svd_rotmat_sites)  
+    }  
   }else{
-    M <- cbind(object$params$beta0, optima(object,sd.errors=F)%*%svd_rotmat_sites)  
+    M <- cbind(object$params$beta0)
   }
+  
   
   sumry <- list()
   sumry$digits <- digits

--- a/R/summary.gllvm.R
+++ b/R/summary.gllvm.R
@@ -281,7 +281,7 @@ print.summary.gllvm <- function (x, ...)
       phi <- x$'Standard deviations'
     }
     if(x$family%in%c("negative.binomial","gamma","tweedie","ZIP","gaussian")){
-      names(phi) <- row.names(x$Coefficients)
+      # names(phi) <- row.names(x$Coefficients)
       cat("\n(Dispersion estimates for ", x$family, ":\n")
       print(phi)
     }

--- a/man/gllvm.Rd
+++ b/man/gllvm.Rd
@@ -33,6 +33,7 @@ gllvm(
   scale.X = TRUE,
   return.terms = TRUE,
   gradient.check = FALSE,
+  disp.group = NULL,
   control = list(reltol = 1e-10, TMB = TRUE, optimizer = "optim", max.iter = 2000,
     maxit = 4000, trace = FALSE, optim.method = NULL),
   control.va = list(Lambda.struc = "unstructured", Ab.struct = "unstructured", Ar.struc
@@ -99,6 +100,8 @@ gllvm(
 \item{return.terms}{logical, if \code{TRUE} 'terms' object is returned.}
 
 \item{gradient.check}{logical, if \code{TRUE} gradients are checked for large values (>0.01) even if the optimization algorithm did converge.}
+
+\item{disp.group}{vector of indices for the grouping of dispersion parameters (in e.g., a negative-binomial distribution). Defaults to NULL so that all species have their own dispersion parameter.}
 
 \item{control}{A list with the following arguments controlling the optimization:
 \itemize{

--- a/man/ordiplot.gllvm.Rd
+++ b/man/ordiplot.gllvm.Rd
@@ -21,8 +21,11 @@
   cex.spp = 0.7,
   spp.colors = "blue",
   arrow.scale = 0.8,
+  arrow.spp.scale = 0.8,
   arrow.ci = TRUE,
+  arrow.lty = "solid",
   spp.arrows = NULL,
+  spp.arrow.lty = "dashed",
   cex.env = 0.7,
   lab.dist = 0.1,
   lwd.ellips = 0.5,
@@ -62,9 +65,13 @@
 
 \item{arrow.scale}{positive value, to scale arrows}
 
+\item{arrow.spp.scale}{positive value, to scale arrows of species}
+
 \item{arrow.ci}{represent statistical uncertainty for arrows in constrained ordinatioon using confidence interval? Defaults to \code{TRUE}}
 
-\item{spp.arrows}{plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.}
+\item{arrow.lty}{linetype for arrows in constrained}
+
+\item{spp.arrow.lty}{linetype for species arrows}
 
 \item{cex.env}{size of labels for arrows in constrianed ordination}
 
@@ -77,6 +84,8 @@
 \item{lty.ellips}{line type for prediction ellipses. See graphical parameter lty.}
 
 \item{...}{additional graphical arguments.}
+
+\item{spp.arrow}{plot species scores as arrows if outside of the range of the plot? Defaults to \code{FALSE} for linear response models and \code{TRUE} for quadratic response models.}
 }
 \description{
 Plots latent variables and their corresponding coefficients (biplot).


### PR DESCRIPTION
This PR adds an option to assume dispersion parameters are grouped across responses (`disp.group` is a vector of indices that can be provided in `gllvm(.)`, for example: `disp.group = c(rep(1,5),rep(2,5))`, similar to e.g., the cut-offs for the ordinal model. I've found this to be useful for datasets with few sites, and while (say) analyzing specific species groups simultaneously (my example concerns pollinators and plants)

There are also some small bugfixes for the ordiplot function, when using arrows and species colors.