### PR TITLE
Fixes for residual plots.

### DIFF
--- a/R/plot.gllvm.R
+++ b/R/plot.gllvm.R
@@ -48,7 +48,7 @@
 
 
 plot.gllvm <- function(x, which = 1:5, caption = c("Residuals vs linear predictors", "Normal Q-Q",
-                       "Residuals vs row", "Residuals vs column", "Scale-Location"), 
+                                                   "Residuals vs row", "Residuals vs column", "Scale-Location"), 
                        var.colors = NULL, add.smooth = TRUE, envelopes = TRUE, reps = 150, 
                        envelope.col = c("blue","lightblue"), n.plot = NULL, ...) {
   n <- NROW(x$y)
@@ -58,16 +58,16 @@ plot.gllvm <- function(x, which = 1:5, caption = c("Residuals vs linear predicto
   if(!is.null(n.plot)) {
     sppind <- sort(sample(1:p, n.plot))
     p <- n.plot
-    }
-
+  }
+  
   mains <- rep("", 4)
   mains[which] <- caption[which]
-
+  
   res <- residuals(x)
   ds.res <- res$residuals[,sppind]
   eta.mat <- res$linpred[,sppind]
   xxx <- boxplot(c(eta.mat), outline = FALSE,plot = FALSE)$stats
-
+  
   csum = order(colSums(as.matrix(x$y))[sppind])
   if (!is.null(var.colors)) {
     col <- rep(1, p)
@@ -79,67 +79,67 @@ plot.gllvm <- function(x, which = 1:5, caption = c("Residuals vs linear predicto
     col <- (grDevices::rainbow(p + 1)[2:(p + 1)])[csum]
   
   gr.pars <- list(...)
-par(...)
-
-    if(1 %in% which) {
-      if(is.null(gr.pars$xlim)) {
-        plot(eta.mat, ds.res, xlab = "linear predictors", ylab = "Dunn-Smyth-residuals",
-             type = "n", col = rep(col, each = n), main = mains[1], xlim = c(min(xxx), max(xxx))); abline(0, 0, col = "grey", lty = 3)
-      } else {
-        plot(eta.mat, ds.res, xlab = "linear predictors", ylab = "Dunn-Smyth-residuals", type =
-               "n", col = rep(col, each = n), main = mains[1], ...); abline(0, 0, col = "grey", lty = 3)
-        }
-
-      if(add.smooth) gamEnvelope(eta.mat, ds.res, col = rep(col, each = n), envelopes = envelopes, envelope.col = envelope.col, ...)
-#      panel(eta.mat, ds.res, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
+  par(...)
+  
+  if(1 %in% which) {
+    if(is.null(gr.pars$xlim)) {
+      plot(eta.mat, ds.res, xlab = "linear predictors", ylab = "Dunn-Smyth-residuals",
+           type = "n", col = rep(col[csum], each = n), main = mains[1], xlim = c(min(xxx), max(xxx))); abline(0, 0, col = "grey", lty = 3)
+    } else {
+      plot(eta.mat, ds.res, xlab = "linear predictors", ylab = "Dunn-Smyth-residuals", type =
+             "n", col = rep(col[csum], each = n), main = mains[1], ...); abline(0, 0, col = "grey", lty = 3)
     }
-    if(2 %in% which) {
-      qq.x<-qqnorm(c(ds.res), main = mains[2], ylab = "Dunn-Smyth residuals", col = rep(col, each = n), cex = 0.5, xlab = "theoretical quantiles");
-      qqline(c(res$residuals), col = envelope.col[1])
-      if(envelopes){
-        K <- reps
-        yy <- quantile(ds.res, c(0.25, 0.75), names = FALSE, type = 7, na.rm = TRUE)
-        xx <- qnorm(c(0.25, 0.75))
-        slope <- diff(yy) / diff(xx)
-        int <- yy[1L] - slope * xx[1L]
-        Xm <- Ym <- NULL
-        for (i in 1:K) {
-          ri <- (rnorm(n * p, int, sd = slope))
-          Ym <- cbind(Ym, sort(ri))
-        }
-        Xm <- sort(qq.x$x)
-        cis <- apply(Ym, 1, quantile, probs = c(0.025, 0.975))
-
-        n.obs <- n*p
-        polygon(Xm[c(1:n.obs,n.obs:1)], c(cis[1, ],cis[2, n.obs:1]), col = envelope.col[2], border = NA)
-        points(qq.x, col = rep(col, each = n), cex = 0.5)
-        qqline(c(res$residuals), col = envelope.col[1])
-      }
-      }
-    if(3 %in% which) {
-      plot(rep(1:n, p), ds.res, xlab = "site index", ylab = "Dunn-Smyth-residuals", col =
-             rep(col, each = n), main = mains[3], ...);
-      abline(0, 0, col = "grey", lty = 3)
-      if(add.smooth) panel.smooth(rep(1:n, p), ds.res, col = rep(col, each = n), col.smooth = envelope.col[1],...)
-      #panel(rep(1:n, p), ds.res, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
-    }
-    if(4 %in% which) {
-      plot(rep(1:p, each = n), ds.res, xlab = "species index", ylab = "Dunn-Smyth-residuals", col =
-             rep(col[csum], each = n), main = mains[4], ...);  abline(0, 0, col = "grey", lty = 3)
-      if(add.smooth) panel.smooth(rep(1:p, each = n), ds.res, col = rep(col[csum], each = n), col.smooth = envelope.col[1], ...)
-      #panel(rep(1:p, each = n), ds.res, col = rep(col[csum], each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
-    }
-    if(5 %in% which) {
-      sqres <- sqrt(abs(ds.res))
-      yl <- as.expression(substitute(sqrt(abs(YL)), list(YL = as.name("Dunn-Smyth-residuals"))))
-      if(is.null(gr.pars$xlim)) {
-        plot(eta.mat, sqres, xlab = "linear predictors", ylab = yl, col = rep(col, each = n),
-             main = mains[5], xlim = c(min(xxx), max(xxx)), ...);
-      } else {
-        plot(eta.mat, sqres, xlab = "linear predictors", ylab = yl, col = rep(col, each = n), main = mains[5], ...);
-      }
-      if(add.smooth) panel.smooth(eta.mat, sqres, col = rep(col, each = n), col.smooth = envelope.col[1], ...)
-      #panel(eta.mat, sqres, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
+    
+    if(add.smooth) gamEnvelope(eta.mat, ds.res, col = rep(col[csum], each = n), envelopes = envelopes, envelope.col = envelope.col, ...)
+    #      panel(eta.mat, ds.res, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
   }
-
+  if(2 %in% which) {
+    qq.x<-qqnorm(c(ds.res), main = mains[2], ylab = "Dunn-Smyth residuals", col = rep(col[csum], each = n), cex = 0.5, xlab = "theoretical quantiles");
+    qqline(c(res$residuals), col = envelope.col[1])
+    if(envelopes){
+      K <- reps
+      yy <- quantile(ds.res, c(0.25, 0.75), names = FALSE, type = 7, na.rm = TRUE)
+      xx <- qnorm(c(0.25, 0.75))
+      slope <- diff(yy) / diff(xx)
+      int <- yy[1L] - slope * xx[1L]
+      Xm <- Ym <- NULL
+      for (i in 1:K) {
+        ri <- (rnorm(n * p, int, sd = slope))
+        Ym <- cbind(Ym, sort(ri))
+      }
+      Xm <- sort(qq.x$x)
+      cis <- apply(Ym, 1, quantile, probs = c(0.025, 0.975))
+      
+      n.obs <- n*p
+      polygon(Xm[c(1:n.obs,n.obs:1)], c(cis[1, ],cis[2, n.obs:1]), col = envelope.col[2], border = NA)
+      points(qq.x, col = rep(col[csum], each = n), cex = 0.5)
+      qqline(c(res$residuals), col = envelope.col[1])
+    }
+  }
+  if(3 %in% which) {
+    plot(rep(1:n, p), ds.res, xlab = "site index", ylab = "Dunn-Smyth-residuals", col =
+           rep(col[csum], each = n), main = mains[3], ...);
+    abline(0, 0, col = "grey", lty = 3)
+    if(add.smooth) panel.smooth(rep(1:n, p), ds.res, col = rep(col[csum], each = n), col.smooth = envelope.col[1], cex = NA, ...)
+    #panel(rep(1:n, p), ds.res, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
+  }
+  if(4 %in% which) {
+    plot(rep(1:p, each = n), ds.res, xlab = "species index", ylab = "Dunn-Smyth-residuals", col =
+           rep(col[csum], each = n), main = mains[4], ...);  abline(0, 0, col = "grey", lty = 3)
+    if(add.smooth) panel.smooth(rep(1:p, each = n), ds.res, col = rep(col[csum], each = n), col.smooth = envelope.col[1], cex = NA, ...)
+    #panel(rep(1:p, each = n), ds.res, col = rep(col[csum], each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
+  }
+  if(5 %in% which) {
+    sqres <- sqrt(abs(ds.res))
+    yl <- as.expression(substitute(sqrt(abs(YL)), list(YL = as.name("Dunn-Smyth-residuals"))))
+    if(is.null(gr.pars$xlim)) {
+      plot(eta.mat, sqres, xlab = "linear predictors", ylab = yl, col = rep(col[csum], each = n),
+           main = mains[5], xlim = c(min(xxx), max(xxx)), ...);
+    } else {
+      plot(eta.mat, sqres, xlab = "linear predictors", ylab = yl, col = rep(col[csum], each = n), main = mains[5], ...);
+    }
+    if(add.smooth) panel.smooth(eta.mat, sqres, col = rep(col[csum], each = n), col.smooth = envelope.col[1], cex = NA, ...)
+    #panel(eta.mat, sqres, col = rep(col, each = n), cex = 1, cex.lab = 1, cex.axis = 1, lwd = 1)
+  }
+  
 }


### PR DESCRIPTION
Some bugfixes for residual plots:

- `col` ->`col[csum]` for correct coloring of points in all plots
- add.smooth = TRUE caused points to be drawn twice. Now, `cex = NA` prevents this.