### PR TITLE
Correction to Hessian

### DIFF
--- a/R/se.gllvm.R
+++ b/R/se.gllvm.R
@@ -324,6 +324,16 @@ se.gllvm <- function(object, ...){
     if(method == "LA"){
       sdr <- optimHess(pars, objrFinal$fn, objrFinal$gr)
     }
+    # makes a small correction to the partial derivatives of LvXcoef if fixed-effect
+    # because of constrained objective function
+    # assumes L(x) = f(x) + lambda*c(x) for constraint function c(x)
+    # though this is not (exactly) how we are fitting the model.
+    if((object$num.RR+object$num.lv.c)>1 && object$randomB==FALSE){
+      b_lvHE <- sdr[names(pars)=="b_lv",names(pars)=="b_lv"]
+      Lmult <- lambda(pars,objrFinal) #estimates  lagranian multiplier
+      sdr[names(pars)=="b_lv",names(pars)=="b_lv"] = b_lvHE + b_lvHEcorrect(Lmult,K = ncol(object$lv.X), d = object$num.lv.c+object$num.RR)
+    }
+    
     m <- dim(sdr)[1]; incl <- rep(TRUE,m); incld <- rep(FALSE,m); inclr <- rep(FALSE,m)
     
     # Not used for this model


### PR DESCRIPTION
This update makes a small correction to the 2nd derivatives of the canonical coefficients in constrained and concurrent ordination models, in order to account for the fact that they lay on a constrained parameter space.

The correction is based on the formulation of the likelihood subject to equality constraints with the method of Lagrange multipliers.

In essence, at the solution, an estimate for the Lagrangian multipliers is retrieved, which is then added to dL/db1db2, i.e., the second partial derivative of the likelihood w.r.t. the canonical coefficients of the same predictor, but on different latent variables.

For constrained ordination the correction seems usually negligible, but for concurrent ordination it usually has a larger effect.

Can immediately be accepted @JenniNiku 