### PR TITLE
Cleaning up SEs processing

### DIFF
--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -1100,7 +1100,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
 
     out <- list( y = y, X = X, lv.X = lv.X, TR = TR, data = datayx, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, num.lvcor =num.lv.cor, lv.formula = lv.formula, lvCor = lvCor, formula = formula,
         method = method, family = family, row.eff = row.eff, rstruc =rstruc, corP=list(cstruc = cstruc, corWithin=corWithin, Astruc=0), dist=dist, randomX = randomX, n.init = n.init,
-        sd = FALSE, Lambda.struc = Lambda.struc, TMB = TMB, beta0com = beta0com, optim.method=optim.method, disp.group = disp.group, NN=NN)
+        sd = FALSE, Lambda.struc = Lambda.struc, TMB = TMB, beta0com = beta0com, optim.method=optim.method, disp.group = disp.group, NN=NN, Ntrials = Ntrials, quadratic = quadratic, randomB = randomB)
     if(return.terms) {out$terms = term} #else {terms <- }
 
     if("la.link.bin" %in% names(pp.pars)){link = pp.pars$la.link.bin}
@@ -1169,7 +1169,8 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             scalmax = scalmax, MaternKappa = MaternKappa,
             setMap = setMap, #Dthreshold=Dthreshold,
             disp.group = disp.group,
-            Ntrials = Ntrials
+            Ntrials = Ntrials,
+            out = out
         )
         out$X <- fitg$X
         out$TR <- fitg$TR
@@ -1221,7 +1222,8 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             dr=dr, rstruc =rstruc, cstruc = cstruc, dist =dist, corWithin = corWithin, NN=NN, 
             scalmax = scalmax, MaternKappa = MaternKappa,
             setMap=setMap, #Dthreshold=Dthreshold,
-            disp.group = disp.group
+            disp.group = disp.group, 
+            out = out
         )
         if(is.null(formula)) {
           out$formula <- fitg$formula
@@ -1234,7 +1236,6 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
       out$X.design <- fitg$X.design
       out$TMBfn = fitg$TMBfn
       out$logL <- fitg$logL
-      out$randomB = randomB
       if (num.lv|num.lv.c > 0)
         out$lvs <- fitg$lvs
       # out$X <- fitg$X

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -8,7 +8,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
                       seed = NULL,maxit = 3000, max.iter=200, start.lvs = NULL, offset=NULL, sd.errors = FALSE,
                       trace=FALSE,link="logit",n.init=1,n.init.max = 10, restrict=30,start.params=NULL, dr=NULL, rstruc =0, cstruc = "diag", dist =matrix(0),
                       optimizer="optim",starting.val="res",Power=1.5,diag.iter=1, dependent.row = FALSE, scalmax = 10, MaternKappa = 1.5,
-                      Lambda.start=c(0.1,0.5), quad.start=0.01, jitter.var=0, zeta.struc = "species", quadratic = FALSE, start.struc = "LV", optim.method = "BFGS", disp.group = NULL, NN=matrix(0), setMap=NULL, Ntrials = 1) { 
+                      Lambda.start=c(0.1,0.5), quad.start=0.01, jitter.var=0, zeta.struc = "species", quadratic = FALSE, start.struc = "LV", optim.method = "BFGS", disp.group = NULL, NN=matrix(0), setMap=NULL, Ntrials = 1, out = NULL) { 
   # , Dthreshold=0
   # If there is no random effects/LVs set diag iter to zero:
   if(((num.lv+num.lv.c)==0) & (row.eff!="random") & (randomB==FALSE)) diag.iter <-  0
@@ -232,7 +232,14 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   
   n.i <- 1
   if(starting.val!="zero"){seed.best <- seed[n.i]}else{seed.best <- NULL}
-  out <- list( y = y, X = X, logL = Inf, num.lv = num.lv, num.lv.c = num.lv.c, row.eff = row.eff, family = family, X.design = X, method = method, zeta.struc = zeta.struc, Ntrials = Ntrials)
+  if(is.null(out)){
+    out <- list( y = y, X = X, logL = Inf, num.lv = num.lv, num.lv.c = num.lv.c, row.eff = row.eff, family = family, X.design = X, method = method, zeta.struc = zeta.struc, Ntrials = Ntrials)
+  }else{
+    out$logL = Inf
+    out$X.design = X
+    out$zeta.struc = zeta.struc
+    out$TMB = TRUE 
+  }
   #if (n.init > 1)
   
   # n.init model fits
@@ -511,6 +518,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     if((num.lv.c+num.RR)==0){
       map.list$b_lv = factor(rep(NA, length(b.lv)))
     }
+    if((num.lv+num.lv.c)==0)map.list$sigmaLV = factor(NA)
     
     randoml=c(0,0,0)
     if(row.eff=="fixed"){xr <- matrix(1,1,p)} else {xr <- matrix(0,1,p)}
@@ -2157,363 +2165,11 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   # }
   
   #### Try to calculate sd errors
-  
-  tr <- try({
-    if(sd.errors && !is.infinite(out$logL)) {
-      if(trace) cat("Calculating standard errors for parameters...\n")
-      out$TMB <- TRUE
-      # out <- c(out, se.gllvm(out))
-      
-      if(family %in% c("ZIP","ZINB")) {
-        p0i <- names(pars)=="lg_phi"
-        p0 <- pars[p0i]
-        p0 <- p0+runif(length(unique(disp.group)),0,0.001)
-        pars[p0i] <- p0
-      }
-      if(family %in% c("ZINB")) {
-        p0iZINB <- names(pars)=="lg_phiZINB"
-        p0ZINB <- pars[p0iZINB]
-        p0ZINB <- p0ZINB+runif(length(unique(disp.group)),0,0.001)
-        pars[p0iZINB] <- p0ZINB
-      }
-      if((method %in% c("VA", "EVA"))){
-        sdr <- objrFinal$he(pars)
-      }
-      if(method == "LA"){
-        sdr <- optimHess(pars, objrFinal$fn, objrFinal$gr, control = list(reltol=reltol,maxit=maxit))#maxit=maxit
-      }
-      # makes a small correction to the partial derivatives of LvXcoef if fixed-effect
-      # because of constrained objective function
-      # assumes L(x) = f(x) + lambda*c(x) for constraint function c(x)
-      # though this is not (exactly) how we are fitting the model.
-      if((num.RR+num.lv.c)>1 && randomB==FALSE){
-        b_lvHE <- sdr[names(pars)=="b_lv",names(pars)=="b_lv"]
-        Lmult <- lambda(pars,objrFinal) #estimates  lagranian multiplier
-        sdr[names(pars)=="b_lv",names(pars)=="b_lv"] = b_lvHE + b_lvHEcorrect(Lmult,K = ncol(lv.X), d = num.lv.c+num.RR)
-      }
-      
-      m <- dim(sdr)[1]; incl <- rep(TRUE,m); incld <- rep(FALSE,m); inclr <- rep(FALSE,m)
-      incl[names(objrFinal$par)=="ePower"] <- FALSE
-      # Not used for this model
-      incl[names(objrFinal$par)=="B"] <- FALSE
-      incl[names(objrFinal$par)%in%c("Br","sigmaB","sigmaij")] <- FALSE
-      
-      # Variational params not included for incl
-      incl[names(objrFinal$par)=="Ab_lv"] <- FALSE;
-      incl[names(objrFinal$par)=="Abb"] <- FALSE;
-      incl[names(objrFinal$par)=="lg_Ar"] <- FALSE;
-      incl[names(objrFinal$par)=="Au"] <- FALSE;
-      incl[names(objrFinal$par)=="u"] <- FALSE;
-      
-      #slopes for reduced rank predictors
-      if((num.lv.c+num.RR)==0){
-        incl[names(objrFinal$par)=="sigmab_lv"] <- FALSE
-        incl[names(objrFinal$par)=="b_lv"] <- FALSE
-      }else if((num.lv.c+num.RR)>0&randomB==FALSE){
-        incl[names(objrFinal$par)=="b_lv"] <- TRUE
-        incl[names(objrFinal$par)=="sigmab_lv"] <- FALSE
-      }else if((num.lv.c+num.RR>0)&randomB!=FALSE){
-        incl[names(objrFinal$par)=="b_lv"] <- FALSE
-        
-        inclr[names(objrFinal$par)=="b_lv"] <- TRUE
-        incld[names(objrFinal$par)=="b_lv"] <- TRUE
-        
-        incld[names(objrFinal$par)=="Ab_lv"] <- TRUE
-        
-        incl[names(objrFinal$par)=="sigmab_lv"] <- TRUE
-      }
-      
-      #loadings for quadratic models
-      if(quadratic == FALSE){incl[names(objrFinal$par)=="lambda2"]<-FALSE}
-      
-      if(familyn!=7) incl[names(objrFinal$par)=="zeta"] <- FALSE
-      if(familyn==0 || familyn==2 || familyn==7 || familyn==8) incl[names(objrFinal$par)=="lg_phi"] <- FALSE
-      if(familyn!=11) incl[names(objrFinal$par)=="lg_phiZINB"] <- FALSE
-      if(family!=10)incl[names(objrFinal$par)=="etaH"] <- FALSE
-      
-      if((num.lv+num.lv.c)>0){
-        inclr[names(objrFinal$par)=="u"] <- TRUE;
-        incld[names(objrFinal$par)=="u"] <- TRUE;
-        incld[names(objrFinal$par)=="Au"] <- TRUE;
-      } else {
-        #only set lambda to FALSE if all dimensions are zero
-        if(num.RR==0)incl[names(objrFinal$par)=="lambda"] <- FALSE;
-        #set sigmaLV to zero if no latent variables
-        incl[names(objrFinal$par)=="sigmaLV"] <- FALSE;
-        
-      }
-      
-      if(row.eff=="random") {
-        incld[names(objrFinal$par) == "lg_Ar"] <- TRUE
-        incld[names(objrFinal$par) == "r0"] <- TRUE
-        inclr[names(objrFinal$par) == "r0"] <- TRUE;
-        incl[names(objrFinal$par) == "r0"] <- FALSE; 
-      } else {
-        incl[names(objrFinal$par)=="log_sigma"] <- FALSE
-        if(row.eff==FALSE) { incl[names(objrFinal$par)=="r0"] <- FALSE }
-        if(row.eff=="fixed"){ incl[1] <- FALSE }
-      }
-      
-      if(method=="LA" || ((num.lv+num.lv.c)==0 && (method %in% c("VA", "EVA")) && row.eff!="random" && randomB == FALSE)){
-        covM <- try(MASS::ginv(sdr[incl,incl]))
-        se <- try(sqrt(diag(abs(covM))))
-        trpred<-try({
-          if(((num.lv+num.lv.c+num.RR) > 0 || row.eff == "random")&& method == "LA") {
-            sd.random <- sdrandom(objrFinal, covM, incl,ignore.u = ignore.u)
-            prediction.errors <- list()
-            
-            if(row.eff=="random"){
-              prediction.errors$row.params <- sd.random$row
-            }
-            if((num.lv+num.lv.c+num.RR)>0){
-              # cov.lvs <- array(0, dim = c(n, num.lv+num.lv.c, num.lv+num.lv.c))
-              # for (i in 1:n) {
-              #   cov.lvs[i,,] <- as.matrix(sd.random[(0:(num.lv+num.lv.c-1)*n+i),(0:(num.lv+num.lv.c-1)*n+i)])
-              # cov.lvs[i,,] <- as.matrix(sd.random[(0:(nlvr-1)*n+i),(0:(nlvr-1)*n+i)])
-              #}
-              # if(row.eff=="random"){
-              #   prediction.errors$row.params <- cov.lvs[,1,1]
-              #   if(num.lv > 0) cov.lvs <- array(cov.lvs[,-1,-1], dim = c(n, num.lv, num.lv))
-              # }
-              prediction.errors$lvs <- sd.random$A
-              if(randomB!=FALSE){
-                prediction.errors$Ab.lv <- sd.random$Ab_lv
-              }
-            }
-            
-            out$prediction.errors <- prediction.errors
-          }
-        }, silent = TRUE)
-        if(inherits(trpred, "try-error")) { cat("Prediction errors for latent variables could not be calculated.\n") }
-        out$Hess <- list(Hess.full=sdr, incla = NULL, incl=incl, incld=NULL, cov.mat.mod=covM)
-        
-      } else {
-        
-        A.mat <- sdr[incl, incl] # a x a
-        D.mat <- sdr[incld, incld] # d x d
-        B.mat <- sdr[incl, incld] # a x d
-        
-        try({
-          cov.mat.mod<- try(MASS::ginv(A.mat-B.mat%*%solve(D.mat, t(B.mat))),silent=T)
-          if(inherits(cov.mat.mod,"try-error")){
-            # block inversion via inverse of fixed-effects block
-            Ai <- try(solve(A.mat),silent=T)
-            cov.mat.mod <- try(Ai+Ai%*%B.mat%*%MASS::ginv(D.mat-t(B.mat)%*%Ai%*%B.mat)%*%t(B.mat)%*%Ai,silent=T)
-          }
-          se <- sqrt(diag(abs(cov.mat.mod)))
-          
-          incla<-rep(FALSE, length(incl))
-          incla[names(objrFinal$par)=="u"] <- TRUE
-          
-          out$Hess <- list(Hess.full=sdr, incla = incla, incl=incl, incld=incld, cov.mat.mod=cov.mat.mod)
-        }, silent = TRUE)
-        
-      }
-      
-      if(row.eff == "fixed") {
-        se.row.params <- c(0,se[1:(n-1)]); 
-        names(se.row.params) <- rownames(out$y); se <- se[-(1:(n-1))] 
-      }
-      sebetaM <- matrix(se[1:((num.X+1)*p)],p,num.X+1,byrow=TRUE);  
-      se <- se[-(1:((num.X+1)*p))]
-      
-      if(family %in% "betaH"){
-        out$sd$betaH <- matrix(se[1:((num.X+1)*p)],p,num.X+1,byrow=TRUE);  se <- se[-(1:((num.X+1)*p))]
-        rownames(out$sd$betaH) <- rownames(out$params$betaH); 
-        colnames(out$sd$betaH) <- colnames(out$params$betaH)
-      }
-      
-      
-      if((num.lv.c+num.RR)>0 & (randomB==FALSE)){
-        se.LvXcoef <- matrix(se[1:((num.lv.c+num.RR)*ncol(lv.X))],ncol=(num.lv.c+num.RR),nrow=ncol(lv.X))
-        se <- se[-c(1:((num.lv.c+num.RR)*ncol(lv.X)))]
-        colnames(se.LvXcoef) <- paste("CLV",1:(num.lv.c+num.RR),sep="")
-        row.names(se.LvXcoef) <- colnames(lv.X)
-        out$sd$LvXcoef <- se.LvXcoef
-      }
-      
-      if((num.lv.c+num.lv)>0){
-        se.sigma.lv <- se[1:(num.lv+num.lv.c)]; ##*out$params$sigma.lv; 
-        se<-se[-c(1:(num.lv+num.lv.c))]
-      }
-      
-      if(num.lv > 0&(num.lv.c+num.RR)==0) {
-        se.lambdas <- matrix(0,p,num.lv); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se[1:(p * num.lv - sum(0:num.lv))];
-        colnames(se.lambdas) <- paste("LV", 1:num.lv, sep="");
-        rownames(se.lambdas) <- colnames(out$y)
-        out$sd$theta <- se.lambdas; 
-        if((p * num.lv - sum(0:num.lv))>0) se <- se[-(1:(p * num.lv - sum(0:num.lv)))];
-        if(quadratic==TRUE){
-          se.lambdas2 <- matrix(se[1:(p * num.lv)], p, num.lv, byrow = T)  
-          colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-          se <- se[-(1:(num.lv*p))]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }else if(quadratic=="LV"){
-          se.lambdas2 <- matrix(se[1:num.lv], p, num.lv, byrow = T)
-          colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-          se <- se[-(1:num.lv)]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }
-      }else if(num.lv==0&(num.lv.c+num.RR)>0){
-        se.lambdas <- matrix(0,p,(num.lv.c+num.RR)); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
-        
-        colnames(se.lambdas) <- paste("CLV", 1:(num.lv.c+num.RR), sep="");
-        rownames(se.lambdas) <- colnames(out$y)
-        out$sd$theta <- se.lambdas; se <- se[-(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
-        
-        if(quadratic==TRUE){
-          se.lambdas2 <- matrix(se[1:(p * (num.lv.c+num.RR))], p, (num.lv.c+num.RR), byrow = T)  
-          colnames(se.lambdas2) <- paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = "")
-          se <- se[-(1:((num.lv.c+num.RR)*p))]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }else if(quadratic=="LV"){
-          se.lambdas2 <- matrix(se[1:(num.lv.c+num.RR)], p, (num.lv.c+num.RR), byrow = T)
-          colnames(se.lambdas2) <- paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = "")
-          se <- se[-(1:(num.lv.c+num.RR))]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }
-        
-      }else if(num.lv>0&(num.lv.c+num.RR)>0){
-        se.lambdas <- matrix(0,p,num.lv+(num.lv.c+num.RR));
-        se.lambdas[,1:(num.lv.c+num.RR)][lower.tri(se.lambdas[,1:(num.lv.c+num.RR),drop=F], diag=FALSE)] <- se[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
-        se <- se[-c(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
-        se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas)][lower.tri(se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas),drop=F], diag=FALSE)] <- se[1:(p * num.lv - sum(0:num.lv))];
-        if((p * num.lv - sum(0:num.lv))>0) se <- se[-c(1:(p * num.lv - sum(0:num.lv)))]
-        colnames(se.lambdas) <- c(paste("CLV", 1:(num.lv.c+num.RR), sep=""),paste("LV", 1:num.lv, sep=""));
-        rownames(se.lambdas) <- colnames(out$y)
-        out$sd$theta <- se.lambdas;
-        
-        if(quadratic==TRUE){
-          se.lambdas2 <- matrix(se[1:(p * ((num.lv.c+num.RR)+num.lv))], p, (num.lv.c+num.RR)+num.lv, byrow = T)  
-          colnames(se.lambdas2) <- c(paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = ""),paste("LV", 1:num.lv, "^2", sep = ""))
-          se <- se[-(1:((num.lv+(num.lv.c+num.RR))*p))]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }else if(quadratic=="LV"){
-          se.lambdas2 <- matrix(se[1:((num.lv.c+num.RR)+num.lv)], p, (num.lv.c+num.RR)+num.lv, byrow = T)
-          colnames(se.lambdas2) <- c(paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = ""),paste("LV", 1:num.lv, "^2", sep = ""))
-          se <- se[-(1:((num.lv.c+num.RR)+num.lv))]
-          out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
-        }
-        
-      }
-      
-      if(num.lv>0 & family == "betaH"){
-        se.thetaH <- matrix(0,num.lv,p); 
-        se.thetaH[upper.tri(se.thetaH, diag=TRUE)] <- se[1:(sum(upper.tri(se.thetaH, diag=TRUE)))];
-        se <- se[-( 1:sum(upper.tri(se.thetaH, diag=TRUE)) )];
-        out$sd$se.thetaH <- se.thetaH
-      }
-      
-      if((num.lv+num.lv.c)>0){
-        out$sd$sigma.lv  <- se.sigma.lv
-        names(out$sd$sigma.lv) <- colnames(out$params$theta[,1:(num.lv+(num.lv.c))])
-      }
-      
-      out$sd$beta0 <- sebetaM[,1]; names(out$sd$beta0) <- colnames(out$y);
-      if(!is.null(X)){
-        out$sd$Xcoef <- matrix(sebetaM[,-1],nrow = nrow(sebetaM));
-        rownames(out$sd$Xcoef) <- colnames(y); colnames(out$sd$Xcoef) <- colnames(X);
-      }
-      if(row.eff=="fixed") {out$sd$row.params <- se.row.params}
-      
-      if(family %in% c("ZINB")) {
-        se.ZINB.lphis <- se[1:length(unique(disp.group))][disp.group];  out$sd$ZINB.inv.phi <- se.ZINB.lphis*out$params$ZINB.inv.phi;
-        out$sd$ZINB.phi <- se.ZINB.lphis*out$params$ZINB.phi;
-        names(out$sd$ZINB.phi) <- colnames(y);
-        
-        if(!is.null(names(disp.group))){
-          try(names(out$sd$ZINB.phi) <- names(disp.group),silent=T)
-        }
-        names(out$sd$ZINB.inv.phi) <-  names(out$sd$ZINB.phi)
-        se <- se[-(1:length(unique(disp.group)))]
-      }
-      
-      if(family %in% c("negative.binomial")) {
-        se.lphis <- se[1:length(unique(disp.group))][disp.group];  out$sd$inv.phi <- se.lphis*out$params$inv.phi;
-        out$sd$phi <- se.lphis*out$params$phi;
-        names(out$sd$phi) <- colnames(y);
-        
-        if(!is.null(names(disp.group))){
-          try(names(out$sd$phi) <- names(disp.group),silent=T)
-        }
-        names(out$sd$inv.phi) <-  names(out$sd$phi)
-        se <- se[-(1:length(unique(disp.group)))]
-      }
-      
-      if(family %in% c("tweedie", "gaussian", "gamma", "beta", "betaH")) {
-        se.lphis <- se[1:length(unique(disp.group))][disp.group];
-        out$sd$phi <- se.lphis*out$params$phi;
-        names(out$sd$phi) <- colnames(y);
-        if(!is.null(names(disp.group))){
-          try(names(out$sd$phi) <- names(disp.group),silent=T)
-        }
-        
-        se <- se[-(1:length(unique(disp.group)))]
-      }
-      if(family %in% c("ZIP","ZINB")) {
-        se.phis <- se[1:length(unique(disp.group))][disp.group];
-        out$sd$phi <- se.phis*exp(lp0)/(1+exp(lp0))^2;#
-        names(out$sd$phi) <- colnames(y);
-        
-        if(!is.null(names(disp.group))){
-          try(names(out$sd$phi) <- names(disp.group),silent=T)
-        }
-        se <- se[-(1:length(unique(disp.group)))]
-      }
-      if((randomB!=FALSE)&(num.lv.c+num.RR)>0){
-        se.lsigmab.lv <-  se[1:length(out$paramssigmaLvXcoef)];
-        se <-  se[-c(1:length(out$params$sigmaLvXcoef))]
-        out$sd$sigmaLvXcoef <- se.lsigmab.lv*out$params$sigmaLvXcoef
-        if(randomB=="LV")names(out$sd$sigmaLvXcoef) <- paste("CLV",1:(num.lv.c+num.RR), sep="")
-        if(randomB=="P")names(out$sd$sigmaLvXcoef) <- colnames(lv.X)
-        # if(randomB=="all")names(out$sd$sigmaLvXcoef) <- paste(paste("CLV",1:(num.lv.c+num.RR),sep=""),rep(colnames(lv.X),each=num.RR+num.lv.c),sep=".")
-        if(randomB=="single")names(out$sd$sigmaLvXcoef) <- NULL
-      }
-      
-      if(row.eff=="random") {
-        out$sd$sigma <- se[1:length(out$params$sigma)]*c(out$params$sigma[1],rep(1,length(out$params$sigma)-1));
-        se=se[-(1:length(out$sd$sigma))]
-        names(out$sd$sigma) <- "sigma"
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) {out$sd$rho <- se[1]*(1-out$params$rho^2)^1.5; if(length(out$params$rho)) se = se[-(1:length(out$params$rho))]}#*sqrt(1-out$params$rho^2)
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {out$sd$rho <- se[1]*out$params$rho; if(length(out$params$rho)) se = se[-(1:length(out$params$rho))]}
-      }
-      if(num.lv.cor>0 & cstrucn>0){ 
-        if((cstrucn %in% c(1,3))) {out$sd$rho.lv <- se[(1:length(out$params$rho.lv))]*(1-out$params$rho.lv^2)^1.5; se = se[-(1:length(out$params$rho.lv))]}
-        if((cstrucn %in% c(2,4))) {out$sd$rho.lv <- se[(1:length(out$params$rho.lv))]*out$params$rho.lv; se = se[-(1:length(out$params$rho.lv))]}
-        names(out$sd$rho.lv) <- names(out$params$rho.lv)
-        # if((cstrucn %in% c(2,4))) {out$sd$scaledc <- se[(1:length(out$params$scaledc))]*out$params$scaledc; se = se[-(1:length(out$sd$scaledc))]}
-      }
-      
-      if(family %in% c("ordinal")){
-        se.zetanew <- se.zetas <- se;
-        if(zeta.struc == "species"){
-          se.zetanew <- matrix(NA,nrow=p,ncol=K)
-          idx<-0
-          for(j in 1:ncol(y)){
-            k<-max(y[,j])-2
-            if(k>0){
-              for(l in 1:k){
-                se.zetanew[j,l+1]<-se.zetas[idx+l]
-              }
-            }
-            idx<-idx+k
-          }
-          se.zetanew[,1] <- 0
-          out$sd$zeta <- se.zetanew
-          row.names(out$sd$zeta) <- colnames(y00); colnames(out$sd$zeta) <- paste(min(y00):(max(y00)-1),"|",(min(y00)+1):max(y00),sep="")
-          
-        }else{
-          se.zetanew <- c(0, se.zetanew)
-          out$sd$zeta <- se.zetanew
-          names(out$sd$zeta) <- paste(min(y00):(max(y00)-1),"|",(min(y00)+1):max(y00),sep="")
-          
-        }
-      }
-      
-    }}, silent=T)
-  if(inherits(tr, "try-error")) { cat("Standard errors for parameters could not be calculated, due to singular fit.\n") }
-  
-  
+  if(sd.errors && !is.infinite(out$logL)){
+    ses <- se.gllvm(out)
+    out$sd <- ses$sd
+    out$Hess <- ses$Hess
+  }
   return(out)
 }
 

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -3155,3 +3155,25 @@ pzinb <- function(y, mu, sigma)
 #   jacob <- cbind(matrix(0,nrow=nc,ncol=which(names(obj$par)=="b_lv")[1]-1),jacob.B,matrix(0,nrow=nc,ncol=length(x)-tail(which(names(obj$par)=="b_lv"),1)))
 #   return(jacob)
 # }
+
+# function adapted from utils package to re-order gllvm's parameters and/or standard errors
+relist.gllvm <- function (flesh, skeleton = attr(flesh, "skeleton")) 
+{
+  ind <- 1L
+  nam = unique(names(flesh))
+  skeleton <- result <- skeleton[nam]
+  for (i in nam) {
+    skel_i <- result[[i]]
+    size <- length(unlist(skel_i))
+    if(is.matrix(skel_i)){
+      result[[i]] <- relist.matrix.gllvm(flesh[seq.int(ind, length.out = size)], 
+                                         skel_i)
+    }else{
+      result[[i]] <- relist(flesh[seq.int(ind, length.out = size)], 
+                            skel_i)
+    }
+    
+    ind <- ind + size
+  }
+  result
+}

--- a/R/se.gllvm.R
+++ b/R/se.gllvm.R
@@ -120,6 +120,7 @@ se.gllvm <- function(object, ...){
         covM <- try(MASS::ginv(sdr[incl,incl]))
         if(inherits(covM, "try-error")) { stop("Standard errors for parameters could not be calculated, due to singular fit.\n") }
         se <- try(sqrt(diag(abs(covM))))
+        names(se) = names(object$TMBfn$par[incl])
         
         trpred<-try({
           if(num.lv > 0 || object$row.eff == "random" || !is.null(object$randomX)) {
@@ -154,51 +155,49 @@ se.gllvm <- function(object, ...){
         }
         if(inherits(cov.mat.mod, "try-error")) { stop("Standard errors for parameters could not be calculated, due to singular fit.\n") }
         se <- sqrt(diag(abs(cov.mat.mod)))
+        names(se) = names(object$TMBfn$par[incl])
         
         incla<-rep(FALSE, length(incl))
         incla[names(objrFinal$par)=="u"] <- TRUE
         out$Hess <- list(Hess.full=sdr, incla = incla, incl=incl, incld=incld, cov.mat.mod=cov.mat.mod)
         
       }
+
+      # reformat SEs based on the list that went into TMB
+      se <- relist.gllvm(se, object$TMBfn$env$parList())
       
       if(object$row.eff=="fixed") {
-        se.row.params <- c(0,se[1:(n-1)]); 
-        names(se.row.params)  = rownames(object$y); se <- se[-(1:(n-1))] 
+        se.row.params <- c(0,se$r0); 
+        names(se.row.params)  = rownames(object$y);
       }
-      if(object$beta0com){
-        se.beta0 <- se[1]; se <- se[-1];
-      } else {
-        se.beta0 <- se[1:p]; se <- se[-(1:p)];
-      }
+      se.beta0 <- se$b[1,]
+
       if(family %in% "betaH"){
-        out$sd$betaH <- se[1:length(object$params$betaH)];  se <- se[-(1:length(object$params$betaH))]
+        out$sd$betaH <- se$bH
       }
-      se.B <- se[1:length(object$params$B)]; se <- se[-(1:length(object$params$B))];
+      se.B <- se$B
+      
       if(num.lv > 0) {
-        se.sigma.lv <- se[1:num.lv];se<-se[-c(1:num.lv)]
-        se.lambdas <- matrix(0,p,num.lv); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se[1:(p * num.lv - sum(0:num.lv))];
+        se.sigma.lv <- se$sigmaLV[1:num.lv]
+        se.lambdas <- matrix(0,p,num.lv); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se$lambda[1:(p * num.lv - sum(0:num.lv))];
         colnames(se.lambdas) <- paste("LV", 1:num.lv, sep="");
         rownames(se.lambdas) <- colnames(out$y)
         out$sd$theta <- se.lambdas; 
-        if((p * num.lv - sum(0:num.lv))>0) se <- se[-(1:(p * num.lv - sum(0:num.lv)))];
         
         if(quadratic==TRUE){
-          se.lambdas2 <- matrix(se[1:(p * num.lv)], p, num.lv, byrow = T)  
+          se.lambdas2 <- matrix(se$lambda2, p, num.lv, byrow = T)  
           colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-          se <- se[-(1:(num.lv*p))]
           out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
         }else if(quadratic=="LV"){
-          se.lambdas2 <- matrix(se[1:num.lv], p, num.lv, byrow = T)
+          se.lambdas2 <- matrix(se$lambda2, p, num.lv, byrow = T)
           colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-          se <- se[-(1:num.lv)]
           out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
         }
         out$sd$sigma.lv  <- se.sigma.lv
         names(out$sd$sigma.lv) <- colnames(object$params$theta[,1:num.lv])
         if(num.lv>0 & family == "betaH"){
           se.thetaH <- matrix(0,num.lv,p); 
-          se.thetaH[upper.tri(se.thetaH, diag=TRUE)] <- se[1:(sum(upper.tri(se.thetaH, diag=TRUE)))];
-          se <- se[-( 1:sum(upper.tri(se.thetaH, diag=TRUE)) )];
+          se.thetaH[upper.tri(se.thetaH, diag=TRUE)] <- se$thetaH;
           out$sd$se.thetaH <- se.thetaH
         }
         
@@ -209,24 +208,23 @@ se.gllvm <- function(object, ...){
       # }
       out$sd$beta0 <- se.beta0; 
       if(!object$beta0com){ names(out$sd$beta0)  <-  colnames(object$y);}
-      out$sd$B <- se.B; 
+      out$sd$B <- c(se.B); 
       names(out$sd$B) <- names(object$params$B)
       if(object$row.eff=="fixed") {out$sd$row.params <- se.row.params}
       
       if(family %in% c("ZINB")) {
-        se.ZINB.lphis <- se[1:length(unique(disp.group))][disp.group];  out$sd$ZINB.inv.phi <- se.ZINB.lphis*object$params$ZINB.inv.phi;
+        se.ZINB.lphis <- se$lg_phiZINB[disp.group];  out$sd$ZINB.inv.phi <- se.ZINB.lphis*object$params$ZINB.inv.phi;
         out$sd$ZINB.phi <- se.ZINB.lphis*object$params$ZINB.phi;
-        names(out$sd$ZINB.phi) <- colnames(y);
+        names(out$sd$ZINB.phi) <- colnames(object$y);
         
         if(!is.null(names(disp.group))){
           try(names(out$sd$ZINB.phi) <- names(disp.group),silent=T)
         }
         names(out$sd$ZINB.inv.phi) <-  names(out$sd$ZINB.phi)
-        se <- se[-(1:length(unique(disp.group)))]
       }
       
       if(family %in% c("negative.binomial")) {
-        se.lphis <- se[1:length(unique(disp.group))];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
+        se.lphis <- se$lg_phi[disp.group];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
         out$sd$phi <- se.lphis*object$params$phi;
         if(length(unique(disp.group))==p){
           names(out$sd$phi) <- colnames(object$y);
@@ -236,10 +234,10 @@ se.gllvm <- function(object, ...){
           names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
         }
         names(out$sd$inv.phi) <-  names(out$sd$phi)
-        se <- se[-(1:length(unique(disp.group)))]
       }
+      
       if(family %in% c("gaussian","tweedie","gamma", "beta", "betaH")) {
-        se.lphis <- se[1:length(unique(disp.group))];
+        se.lphis <- se$lg_phi[disp.group];
         out$sd$phi <- se.lphis*object$params$phi;
         if(length(unique(disp.group))==p){
           names(out$sd$phi) <- colnames(object$y);
@@ -248,16 +246,15 @@ se.gllvm <- function(object, ...){
         }else{
           names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
         }
-        
-        se <- se[-(1:length(unique(disp.group)))]
       }
       
       if(family%in%c("ZIP","ZINB")) {
         p0i <- names(pars)=="lg_phi"
         p0 <- pars[p0i]
       }
+      
       if(family %in% c("ZIP","ZINB")) {
-        se.phis <- se[1:length(unique(disp.group))];
+        se.phis <- se$lg_phi[disp.group];
         out$sd$phi <- se.phis*exp(p0)/(1+exp(p0))^2;#
         if(length(unique(disp.group))==p){
           names(out$sd$phi) <- colnames(object$y);
@@ -266,29 +263,28 @@ se.gllvm <- function(object, ...){
         }else{
           names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
         }
-        se <- se[-(1:length(unique(disp.group)))]
       }
+      
       if(!is.null(object$randomX)){
         nr <- ncol(xb)
-        out$sd$sigmaB <- se[1:ncol(xb)]*c(sqrt(diag(object$params$sigmaB))); 
+        out$sd$sigmaB <- se$sigmaB*c(sqrt(diag(object$params$sigmaB))); 
         names(out$sd$sigmaB) <- c(paste("sd",colnames(xb),sep = "."))
-        se <- se[-(1:ncol(xb))]
         if(nr>1){
-          out$sd$corrpar <- se[1:(nr*(nr-1)/2)]
-          se <- se[-(1:(nr*(nr-1)/2))]
+          out$sd$corrpar <- se$sigmaij
         }
       }
+      
       if(object$row.eff=="random") { 
-        out$sd$sigma <- se[1:length(object$params$sigma)]*c(object$params$sigma[1],rep(1,length(object$params$sigma)-1)); 
+        out$sd$sigma <- se$log_sigma*c(object$params$sigma[1],rep(1,length(object$params$sigma)-1));
         names(out$sd$sigma) <- "sigma"; 
-        se=se[-(1:(length(object$params$sigma)))] 
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) {out$sd$rho <- se[1]*(1-object$params$rho^2)^1.5; if(length(object$params$rho)) se = se[-(1:length(object$params$rho))]}
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {out$sd$rho <- se[1]*object$params$rho; if(length(object$params$rho)) se = se[-(1:length(object$params$rho))]}
+        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) {out$sd$rho <- se$rho_lvc*(1-object$params$rho^2)^1.5};
+        if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {out$sd$rho <- se$rho_lvc*object$params$rho};
       }
+      
       if(num.lv.cor>0 & cstrucn>0){
         if(length(object$params$rho.lv)>0){
-          if((cstrucn %in% c(1,3))) {out$sd$rho.lv <- se[(1:num.lv.cor)]*(1-object$params$rho.lv^2)^1.5; se = se[-(1:num.lv.cor)]}
-          if((cstrucn %in% c(2,4))) {out$sd$rho.lv <- se[(1:length(object$params$rho.lv))]*object$params$rho.lv; se = se[-(1:length(object$params$rho.lv))]}
+          if((cstrucn %in% c(1,3))) {out$sd$rho.lv <- se$rho_lvc*(1-object$params$rho.lv^2)^1.5}
+          if((cstrucn %in% c(2,4))) {out$sd$rho.lv <- se$rho_lvc*object$params$rho.lv}
           names(out$sd$rho.lv) <- names(object$params$rho.lv)
         }
         # if((cstrucn %in% c(2,4))) {out$sd$scaledc <- se[(1:length(object$params$scaledc))]*object$params$scaledc; se = se[-(1:length(out$sd$scaledc))]}
@@ -298,7 +294,7 @@ se.gllvm <- function(object, ...){
         y <- object$y
         K = max(y)-min(y)
         if(min(y)==0) y <- y+1 
-        se.zetanew <- se.zetas <- se;
+        se.zetanew <- se.zetas <- se$zeta;
         if(object$zeta.struc == "species"){
           se.zetanew <- matrix(NA,nrow=p,ncol=K)
           idx<-0
@@ -413,6 +409,8 @@ se.gllvm <- function(object, ...){
       covM <- try(MASS::ginv(sdr[incl,incl]))
       if(inherits(covM, "try-error")) { stop("Standard errors for parameters could not be calculated, due to singular fit.\n") }
       se <- try(sqrt(diag(abs(covM))))
+      names(se) = names(object$TMBfn$par[incl])
+      
       trpred<-try({
       if((num.lv+num.lv.c) > 0 || object$row.eff == "random"){
         sd.random <- sdrandom(objrFinal, covM, incl, ignore.u = FALSE)
@@ -457,6 +455,7 @@ se.gllvm <- function(object, ...){
       
       if(inherits(cov.mat.mod, "try-error")) { stop("Standard errors for parameters could not be calculated, due to singular fit.\n") }
       se <- sqrt(diag(abs(cov.mat.mod)))
+      names(se) = names(object$TMBfn$par[incl])
       
       incla<-rep(FALSE, length(incl))
       incla[names(objrFinal$par)=="u"] <- TRUE
@@ -464,110 +463,107 @@ se.gllvm <- function(object, ...){
 
     }
     
+    # reformat SEs based on the list that went into TMB
+    se <- relist.gllvm(se, object$TMBfn$env$parList())
+    
     num.X <- 0; if(!is.null(object$X)) num.X <- dim(object$X.design)[2]
     if(object$row.eff == "fixed") { 
-      se.row.params <- c(0,se[1:(n-1)]); 
-      names(se.row.params) <- rownames(object$y); se <- se[-(1:(n-1))] 
+      se.row.params <- c(0,se$r0); 
+      names(se.row.params) <- rownames(object$y);
       }
-    sebetaM <- matrix(se[1:((num.X+1)*p)],p,num.X+1,byrow=TRUE);  
-    se <- se[-(1:((num.X+1)*p))]
-    
-    
+    sebetaM <- matrix(se$b,p,num.X+1,byrow=TRUE);  
+
     if(family %in% "betaH"){
-      out$sd$betaH <- matrix(se[1:((num.X+1)*p)],p,num.X+1,byrow=TRUE);  se <- se[-(1:((num.X+1)*p))]
+      out$sd$betaH <- matrix(se$bH,p,num.X+1,byrow=TRUE);
       rownames(out$sd$betaH) <- rownames(object$params$betaH); 
       colnames(out$sd$betaH) <- colnames(object$params$betaH)
     }
 
     if((num.lv.c+num.RR)>0&object$randomB==FALSE){
-      se.LvXcoef <- matrix(se[1:((num.lv.c+num.RR)*ncol(lv.X))],ncol=num.lv.c+num.RR,nrow=ncol(lv.X))
-      se <- se[-c(1:((num.lv.c+num.RR)*ncol(lv.X)))]
+      se.LvXcoef <- matrix(se$b_lv,ncol=num.lv.c+num.RR,nrow=ncol(lv.X))
       colnames(se.LvXcoef) <- paste("CLV",1:(num.lv.c+num.RR),sep="")
       row.names(se.LvXcoef) <- colnames(lv.X)
       out$sd$LvXcoef <- se.LvXcoef
     }
 
     if((num.lv.c+num.lv)>0){
-      se.sigma.lv <- se[1:(num.lv+num.lv.c)];
-      se<-se[-c(1:(num.lv+num.lv.c))]
+      se.sigma.lv <- se$sigmaLV;
     }
     
     if(num.lv > 0&(num.lv.c+num.RR)==0) {
-      se.lambdas <- matrix(0,p,num.lv); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se[1:(p * num.lv - sum(0:num.lv))];
+      se.lambdas <- matrix(0,p,num.lv); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se$lambda[1:(p * num.lv - sum(0:num.lv))];
       colnames(se.lambdas) <- paste("LV", 1:num.lv, sep="");
       rownames(se.lambdas) <- colnames(object$y)
       out$sd$theta <- se.lambdas; 
-      if((p * num.lv - sum(0:num.lv))>0) se <- se[-(1:(p * num.lv - sum(0:num.lv)))];
+      if(((p * num.lv - sum(0:num.lv))>0) && (num.RR+num.lv.c)>0) se$lambda <- se$lambda[-(1:(p * num.lv - sum(0:num.lv)))];
       
       if(quadratic==TRUE){
-        se.lambdas2 <- matrix(se[1:(p * num.lv)], p, num.lv, byrow = T)  
+        se.lambdas2 <- matrix(se$lambda2[1:(p * num.lv)], p, num.lv, byrow = T)  
         colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-        se <- se[-(1:(num.lv*p))]
+        se$lambda2 <- se$lambda2[-(1:(num.lv*p))]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }else if(quadratic=="LV"){
-        se.lambdas2 <- matrix(se[1:num.lv], p, num.lv, byrow = T)
+        se.lambdas2 <- matrix(se$lambda2[1:num.lv], p, num.lv, byrow = T)
         colnames(se.lambdas2) <- paste("LV", 1:num.lv, "^2", sep = "")
-        se <- se[-(1:num.lv)]
+        se$lambda2 <- se$lambda2[-(1:num.lv)]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }
     }else if(num.lv==0&(num.lv.c+num.RR)>0){
-      se.lambdas <- matrix(0,p,(num.lv.c+num.RR)); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
+      se.lambdas <- matrix(0,p,(num.lv.c+num.RR)); se.lambdas[lower.tri(se.lambdas, diag=FALSE)] <- se$lambda[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
       colnames(se.lambdas) <- paste("CLV", 1:(num.lv.c+num.RR), sep="");
       rownames(se.lambdas) <- colnames(out$y)
-      out$sd$theta <- se.lambdas; se <- se[-(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
+      out$sd$theta <- se.lambdas; se$lambda <- se$lambda[-(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
       
       if(quadratic==TRUE){
-        se.lambdas2 <- matrix(se[1:(p * (num.lv.c+num.RR))], p, (num.lv.c+num.RR), byrow = T)  
+        se.lambdas2 <- matrix(se$lambda2[1:(p * (num.lv.c+num.RR))], p, (num.lv.c+num.RR), byrow = T)  
         colnames(se.lambdas2) <- paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = "")
-        se <- se[-(1:((num.lv.c+num.RR)*p))]
+        se$lambda2 <- se$lambda2[-(1:((num.lv.c+num.RR)*p))]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }else if(quadratic=="LV"){
-        se.lambdas2 <- matrix(se[1:(num.lv.c+num.RR)], p, (num.lv.c+num.RR), byrow = T)
+        se.lambdas2 <- matrix(se$lambda2[1:(num.lv.c+num.RR)], p, (num.lv.c+num.RR), byrow = T)
         colnames(se.lambdas2) <- paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = "")
-        se <- se[-(1:(num.lv.c+num.RR))]
+        se$lambda2 <- se$lambda2[-(1:(num.lv.c+num.RR))]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }
       
     }else if(num.lv>0&(num.lv.c+num.RR)>0){
       se.lambdas <- matrix(0,p,num.lv+(num.lv.c+num.RR));
-      se.lambdas[,1:(num.lv.c+num.RR)][lower.tri(se.lambdas[,1:(num.lv.c+num.RR),drop=F], diag=FALSE)] <- se[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
-      se <- se[-c(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
-      se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas)][lower.tri(se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas),drop=F], diag=FALSE)] <- se[1:(p * num.lv - sum(0:num.lv))];
-      if((p * num.lv - sum(0:num.lv))>0) se <- se[-c(1:(p * num.lv - sum(0:num.lv)))]
+      se.lambdas[,1:(num.lv.c+num.RR)][lower.tri(se.lambdas[,1:(num.lv.c+num.RR),drop=F], diag=FALSE)] <- se$lambda[1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR)))];
+      se$lambda <- se$lambda[-c(1:(p * (num.lv.c+num.RR) - sum(0:(num.lv.c+num.RR))))];
+      se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas)][lower.tri(se.lambdas[,((num.lv.c+num.RR)+1):ncol(se.lambdas),drop=F], diag=FALSE)] <- se$lambda[1:(p * num.lv - sum(0:num.lv))];
+      if(((p * num.lv - sum(0:num.lv))>0) && (num.lv.c + num.RR)>0) se$lambda <- se$lambda[-c(1:(p * num.lv - sum(0:num.lv)))]
       colnames(se.lambdas) <- c(paste("CLV", 1:(num.lv.c+num.RR), sep=""),paste("LV", 1:num.lv, sep=""));
       rownames(se.lambdas) <- colnames(out$y)
       out$sd$theta <- se.lambdas;
       
       if(quadratic==TRUE){
-        se.lambdas2 <- matrix(se[1:(p * ((num.lv.c+num.RR)+num.lv))], p, (num.lv.c+num.RR)+num.lv, byrow = T)  
+        se.lambdas2 <- matrix(se$lambda2[1:(p * ((num.lv.c+num.RR)+num.lv))], p, (num.lv.c+num.RR)+num.lv, byrow = T)  
         colnames(se.lambdas2) <- c(paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = ""),paste("LV", 1:num.lv, "^2", sep = ""))
-        se <- se[-(1:((num.lv+(num.lv.c+num.RR))*p))]
+        se$lambda2 <- se$lambda2[-(1:((num.lv+(num.lv.c+num.RR))*p))]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }else if(quadratic=="LV"){
-        se.lambdas2 <- matrix(se[1:((num.lv.c+num.RR)+num.lv)], p, (num.lv.c+num.RR)+num.lv, byrow = T)
+        se.lambdas2 <- matrix(se$lambda2[1:((num.lv.c+num.RR)+num.lv)], p, (num.lv.c+num.RR)+num.lv, byrow = T)
         colnames(se.lambdas2) <- c(paste("CLV", 1:(num.lv.c+num.RR), "^2", sep = ""),paste("LV", 1:num.lv, "^2", sep = ""))
-        se <- se[-(1:((num.lv.c+num.RR)+num.lv))]
+        se$lambda2 <- se$lambda2[-(1:((num.lv.c+num.RR)+num.lv))]
         out$sd$theta <- cbind(out$sd$theta,se.lambdas2)
       }
     }
     
     if(num.lv>0 & family == "betaH"){
       se.thetaH <- matrix(0,num.lv,p); 
-      se.thetaH[upper.tri(se.thetaH, diag=TRUE)] <- se[1:(sum(upper.tri(se.thetaH, diag=TRUE)))];
-      se <- se[-( 1:sum(upper.tri(se.thetaH, diag=TRUE)) )];
+      se.thetaH[upper.tri(se.thetaH, diag=TRUE)] <- se$thetaH;
       out$sd$se.thetaH <- se.thetaH
     }
     
     if(family %in% c("ZINB")) {
-      se.ZINB.lphis <- se[1:length(unique(disp.group))][disp.group];  out$sd$ZINB.inv.phi <- se.ZINB.lphis*object$params$ZINB.inv.phi;
+      se.ZINB.lphis <- se$lg_phiZINB[disp.group];  out$sd$ZINB.inv.phi <- se.ZINB.lphis*object$params$ZINB.inv.phi;
       out$sd$ZINB.phi <- se.ZINB.lphis*object$params$ZINB.phi;
-      names(out$sd$ZINB.phi) <- colnames(y);
+      names(out$sd$ZINB.phi) <- colnames(object$y);
       
       if(!is.null(names(disp.group))){
         try(names(out$sd$ZINB.phi) <- names(disp.group),silent=T)
       }
       names(out$sd$ZINB.inv.phi) <-  names(out$sd$ZINB.phi)
-      se <- se[-(1:length(unique(disp.group)))]
     }
     
     if((num.lv+num.lv.c)>0){
@@ -587,7 +583,7 @@ se.gllvm <- function(object, ...){
     if(object$row.eff=="fixed") {out$sd$row.params <- se.row.params}
     
     if(family %in% c("negative.binomial")) {
-      se.lphis <- se[1:length(unique(disp.group))];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
+      se.lphis <- se$lg_phi[disp.group];  out$sd$inv.phi <- se.lphis*object$params$inv.phi;
       out$sd$phi <- se.lphis*object$params$phi;
       if(length(unique(disp.group))==p){
         names(out$sd$phi) <- colnames(object$y);
@@ -597,10 +593,10 @@ se.gllvm <- function(object, ...){
         names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
       }
       names(out$sd$inv.phi) <-  names(out$sd$phi)
-      se <- se[-(1:length(unique(disp.group)))]
     }
+    
     if(family %in% c("gaussian","tweedie","gamma", "beta", "betaH")) {
-      se.lphis <- se[1:length(unique(disp.group))];
+      se.lphis <- se$lg_phi[disp.group];
       out$sd$phi <- se.lphis*object$params$phi;
       if(length(unique(disp.group))==p){
         names(out$sd$phi) <- colnames(object$y);
@@ -609,11 +605,10 @@ se.gllvm <- function(object, ...){
       }else{
         names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
       }
-      
-      se <- se[-(1:length(unique(disp.group)))]
     }
+    
     if(family %in% c("ZIP","ZINB")) {
-      se.phis <- se[1:length(unique(disp.group))];
+      se.phis <- se$lg_phi[disp.group];
       out$sd$phi <- se.phis*exp(p0)/(1+exp(p0))^2;#
       if(length(unique(disp.group))==p){
         names(out$sd$phi) <- colnames(object$y);
@@ -622,28 +617,25 @@ se.gllvm <- function(object, ...){
       }else{
         names(out$sd$phi) <- paste("Spp. group", as.integer(unique(disp.group)))
       }
-      se <- se[-(1:length(unique(disp.group)))]
     }
     if((object$randomB!=FALSE)&(num.lv.c+num.RR)>0){
-      se.lsigmab.lv <-  se[1:length(object$paramssigmaLvXcoef)];
-      se <-  se[-c(1:length(object$params$sigmaLvXcoef))]
+      se.lsigmab.lv <-  se$sigmab_lv;
       out$sd$sigmaLvXcoef <- se.lsigmab.lv*object$params$sigmaLvXcoef
       if(object$randomB=="LV")names(out$sd$sigmaLvXcoef) <- paste("CLV",1:(num.lv.c+num.RR), sep="")
       if(object$randomB=="P")names(out$sd$sigmaLvXcoef) <- colnames(lv.X)
       # if(object$randomB=="all")names(out$sd$sigmaLvXcoef) <- paste(paste("CLV",1:(num.lv.c+num.RR),sep=""),rep(colnames(lv.X),each=num.RR+num.lv.c),sep=".")
       if(object$randomB=="single")names(out$sd$sigmaLvXcoef) <- NULL
     }
-    if(object$row.eff=="random") { 
-      out$sd$sigma <- se[1:length(object$params$sigma)]*c(object$params$sigma[1],rep(1,length(object$params$sigma)-1)); 
-      se=se[-(1:length(out$sd$sigma))] 
+    if(object$row.eff=="random") {
+      out$sd$sigma <- se$log_sigma*c(object$params$sigma[1],rep(1,length(object$params$sigma)-1));
       names(out$sd$sigma) <- "sigma" 
-      if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) {out$sd$rho <- se[1]*(1-object$params$rho^2)^1.5; if(length(object$params$rho)) se = se[-(1:length(object$params$rho))]}
-      if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {out$sd$rho <- se[1]*object$params$rho; if(length(object$params$rho)) se = se[-(1:length(object$params$rho))]}
+      if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) {out$sd$rho <- se$rho_lvc*(1-object$params$rho^2)^1.5}
+      if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {out$sd$rho <- se$rho_lvc*object$params$rho}
     }
     if(num.lv.cor>0 & cstrucn>0){ 
       if(length(object$params$rho.lv)>0){
-        if((cstrucn %in% c(1,3))) {out$sd$rho.lv <- se[(1:length(object$params$rho.lv))]*(1-object$params$rho.lv^2)^1.5; se = se[-(1:length(object$params$rho.lv))]}
-        if((cstrucn %in% c(2,4))) {out$sd$rho.lv <- se[(1:length(object$params$rho.lv))]*object$params$rho.lv; se = se[-(1:length(object$params$rho.lv))]}
+        if((cstrucn %in% c(1,3))) {out$sd$rho.lv <- se$rho_lvc*(1-object$params$rho.lv^2)^1.5}
+        if((cstrucn %in% c(2,4))) {out$sd$rho.lv <- se$rho_lvc*object$params$rho.lv}
         names(out$sd$rho.lv) <- names(object$params$rho.lv)
       }
     }
@@ -652,7 +644,7 @@ se.gllvm <- function(object, ...){
       y <- object$y
       K = max(y)-min(y)
       if(min(y)==0) y <- y+1 
-      se.zetanew <- se.zetas <- se;
+      se.zetanew <- se.zetas <- se$zeta;
       if(object$zeta.struc == "species"){
         se.zetanew <- matrix(NA,nrow=p,ncol=K)
         idx<-0

--- a/src/gllvm.cpp
+++ b/src/gllvm.cpp
@@ -1682,12 +1682,12 @@ Type objective_function<Type>::operator() ()
         for (int i=0; i<n; i++) {
           if(!isNA(y(i,j))){
           if(y(i,j)>0){
-            nll -= log(1-iphi(j))+y(i,j)*eta(i,j)-exp(eta(i,j)+cQ(i,j))-lfactorial(y(i,j));
+            nll -= log1p(-iphi(j))+y(i,j)*eta(i,j)-exp(eta(i,j)+cQ(i,j))-lfactorial(y(i,j));
           }else{
-            pVA = ((1-iphi(j))*exp(-exp(eta(i,j)+cQ(i,j))))/(((1-iphi(j)))*exp(-exp(eta(i,j)+cQ(i,j)))+iphi(j));
+            pVA = exp(log1p(-iphi(j))-exp(eta(i,j)+cQ(i,j))-log((1-iphi(j))*exp(-exp(eta(i,j)+cQ(i,j)))+iphi(j)));
             pVA = Type(CppAD::CondExpEq(pVA, Type(1), pVA-Type(1e-12), pVA));//check if pVA is on the boundary
             pVA = Type(CppAD::CondExpEq(pVA, Type(0), pVA+Type(1e-12), pVA));//check if pVA is on the boundary
-            nll -= log(iphi(j))-log(1-pVA);
+            nll -= log(iphi(j))-log1p(-pVA);
           }
           }
         }
@@ -1697,12 +1697,12 @@ Type objective_function<Type>::operator() ()
         for (int i=0; i<n; i++) {
           if(!isNA(y(i,j))){
           if(y(i,j)>0){
-            nll -= log(1-iphi(j))+y(i,j)*eta(i,j)-e_eta(i,j)-lfactorial(y(i,j));
+            nll -= log1p(-iphi(j))+y(i,j)*eta(i,j)-e_eta(i,j)-lfactorial(y(i,j));
           }else{
-            pVA = ((1-iphi(j))*exp(-e_eta(i,j)))/((1-iphi(j))*exp(-e_eta(i,j))+iphi(j));
+            pVA = exp(log1p(-iphi(j))-e_eta(i,j)-log((1-iphi(j))*exp(-e_eta(i,j))+iphi(j)));
             pVA = Type(CppAD::CondExpEq(pVA, Type(1), pVA-Type(1e-12), pVA));//check if pVA is on the boundary
             pVA = Type(CppAD::CondExpEq(pVA, Type(0), pVA+Type(1e-12), pVA));//check if pVA is on the boundary
-            nll -= log(iphi(j))-log(1-pVA);
+            nll -= log(iphi(j))-log1p(-pVA);
           }
           }
         }
@@ -1873,12 +1873,12 @@ Type objective_function<Type>::operator() ()
         for (int i=0; i<n; i++) {
           if(!isNA(y(i,j))){
           if(y(i,j)>0){
-            nll -= log(1-iphi(j))+y(i,j)*(eta(i,j)-cQ(i,j)) - (y(i,j)+iphiZINB(j))*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(y(i,j)+iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j)) -lfactorial(y(i,j));
+            nll -= log1p(-iphi(j))+y(i,j)*(eta(i,j)-cQ(i,j)) - (y(i,j)+iphiZINB(j))*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(y(i,j)+iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j)) -lfactorial(y(i,j));
           }else{
-            pVA = ((1-iphi(j))*exp(- iphiZINB(j)*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j))))/((1-iphi(j))*exp(- iphiZINB(j)*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j)))+iphi(j));
+            pVA = exp(log1p(-iphi(j))- iphiZINB(j)*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j))-log((1-iphi(j))*exp(- iphiZINB(j)*log(iphiZINB(j)+exp(eta(i,j)-cQ(i,j))) + lgamma(iphiZINB(j)) - iphiZINB(j)*cQ(i,j) + iphiZINB(j)*log(iphiZINB(j)) - lgamma(iphiZINB(j)))+iphi(j)));
             pVA = Type(CppAD::CondExpEq(pVA, Type(1), pVA-Type(1e-12), pVA));//check if pVA is on the boundary
             pVA = Type(CppAD::CondExpEq(pVA, Type(0), pVA+Type(1e-12), pVA));//check if pVA is on the boundary
-            nll -= log(iphi(j))-log(1-pVA);
+            nll -= log(iphi(j))-log1p(-pVA);
           }
           }
         }
@@ -1888,12 +1888,12 @@ Type objective_function<Type>::operator() ()
         for (int i=0; i<n; i++) {
           if(!isNA(y(i,j))){
           if(y(i,j)>0){
-            nll -= log(1-iphi(j))-iphiZINB(j)*eta(i,j) -(y(i,j)+iphiZINB(j))*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(y(i,j)+iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j)) -lfactorial(y(i,j));
+            nll -= log1p(-iphi(j))-iphiZINB(j)*eta(i,j) -(y(i,j)+iphiZINB(j))*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(y(i,j)+iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j)) -lfactorial(y(i,j));
           }else{
-            pVA = ((1-iphi(j))*exp(-iphiZINB(j)*eta(i,j) -iphiZINB(j)*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j))))/((1-iphi(j))*exp(-iphiZINB(j)*eta(i,j) -iphiZINB(j)*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j)))+iphi(j));
+            pVA = exp(log1p(-iphi(j))-iphiZINB(j)*eta(i,j) -iphiZINB(j)*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j))-log((1-iphi(j))*exp(-iphiZINB(j)*eta(i,j) -iphiZINB(j)*log(1+iphiZINB(j)*e_eta(i,j))+ lgamma(iphiZINB(j))+ iphiZINB(j)*log(iphiZINB(j)) -lgamma(iphiZINB(j)))+iphi(j)));
             pVA = Type(CppAD::CondExpEq(pVA, Type(1), pVA-Type(1e-12), pVA));//check if pVA is on the boundary
             pVA = Type(CppAD::CondExpEq(pVA, Type(0), pVA+Type(1e-12), pVA));//check if pVA is on the boundary
-            nll -= log(iphi(j))-log(1-pVA);
+            nll -= log(iphi(j))-log1p(-pVA);
           }
           }
         }
@@ -2431,7 +2431,7 @@ Type objective_function<Type>::operator() ()
     for (int i=0; i<n; i++) {
       if(!isNA(y(i,j))){
       if(y(i,j)>0){
-        nll -= log(Type(1)-iphi(j)) + dnbinom_robust(y(i,j), eta(i,j), 2*eta(i,j) - iphiZINB(j), 1);
+        nll -= log1p(-iphi(j)) + dnbinom_robust(y(i,j), eta(i,j), 2*eta(i,j) - iphiZINB(j), 1);
       }else{
         nll -= log(iphi(j) + (Type(1)-iphi(j))*dnbinom_robust(y(i,j), eta(i,j), 2*eta(i,j) - iphiZINB(j), 0)); 
       }


### PR DESCRIPTION
For ease of further maintenance:
- remove se processing from gllvm.TMB
- remove se processing from TMBtrait
- do it all with se.gllvm

this way, we do not need to maintain the processing of SEs in three different places. I also replaced the "se[-c(..)]" with a function in gllvm.aux that splits the se vector by name automatically. This is less prone to bugs, because se[-c(..)] is sensitive to the order of parameters. I.e., previously, if parameter vectors were accidentally placed in the wrong order, the SEs would be wrong. Now, the order no longer matters as matching occurs by name.