### PR TITLE
Multiple row effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+Version 1.4.4
+=============
+* Removed "dependent.row" feature
+* Added possibility for multiple random row intercepts
+
 Version 1.4.3
 ==============
 * For CRAN release 1.4.3 see updates for versions 1.4.2 and 1.4.3

--- a/R/TMBtrait.R
+++ b/R/TMBtrait.R
@@ -3,10 +3,10 @@
 ## Original author: Jenni Niku
 ##########################################################################################
 trait.TMB <- function(
-      y, X = NULL,TR=NULL,formula=NULL, num.lv = 2, family = "poisson", num.lv.cor=0, corWithin = FALSE,
+      y, X = NULL,TR=NULL,formula=NULL, num.lv = 2, family = "poisson", num.lv.cor=0, corWithinLV = FALSE,
       Lambda.struc = "unstructured", Ab.struct = "unstructured", Ar.struc="diagonal", row.eff = FALSE, reltol = 1e-6, seed = NULL,
       maxit = 3000, max.iter=200, start.lvs = NULL, offset=NULL, sd.errors = FALSE,trace=FALSE,
-      link="logit",n.init=1,n.init.max = 10, start.params=NULL,start0=FALSE,optimizer="optim", dr=NULL, dLV=NULL, rstruc =0, cstruc = c("diag","diag"), dist = matrix(0),  scalmax=10, MaternKappa = 1.5,
+      link="logit",n.init=1,n.init.max = 10, start.params=NULL,start0=FALSE,optimizer="optim", dr=NULL, dLV=NULL, cstruc = "diag", cstruclv  ="diag", dist = list(matrix(0)), distLV = matrix(0), scalmax=10, MaternKappa = 1.5,
       starting.val="res",method="VA",randomX=NULL,Power=1.5,diag.iter=1, Ab.diag.iter = 0, dependent.row = FALSE,
       Lambda.start=c(0.2, 0.5), jitter.var=0, yXT = NULL, scale.X = FALSE, randomX.start = "zero", beta0com = FALSE, rangeP = NULL,
       zeta.struc = "species", quad.start=0.01, start.struc="LV",quadratic=FALSE, optim.method = "BFGS", disp.group = NULL, NN=matrix(0), setMap = NULL, Ntrials = 1) {
@@ -19,10 +19,11 @@ trait.TMB <- function(
     stop("Lambda matrix (covariance of variational distribution for latent variable) not permitted...sorry!")
   
   objrFinal <- optrFinal <- NULL
-  cstrucn = c(0,0)
+  cstrucn = 0
   for (i in 1:length(cstruc)) {
     cstrucn[i] = switch(cstruc[i], "diag" = 0, "corAR1" = 1, "corExp" = 2, "corCS" = 3, "corMatern" = 4)
   }
+  cstruclvn = switch(cstruclv, "diag" = 0, "corAR1" = 1, "corExp" = 2, "corCS" = 3, "corMatern" = 4)
   
   term <- NULL
   n <- nr <- nu <- dim(y)[1]; p <- dim(y)[2];
@@ -37,9 +38,9 @@ trait.TMB <- function(
   # Structure for row effects
   model = 1
   xr = NULL
-  if(rstruc==0){ # No structure
-    dr <- diag(n)
-  }
+  # if(rstruc==0){ # No structure
+  #   dr <- diag(n)
+  # }
   if(num.lv.cor==0){ # No structure
     dLV <- diag(n)
   }
@@ -47,70 +48,71 @@ trait.TMB <- function(
   Astruc = 0;
   scaledc = 0;
   rho.lv =NULL
-  if(rstruc>0){#rstruc
-    dist<-as.matrix(dist)
-    if(is.null(dr)) stop("Define structure for row params if 'rstruc == ",rstruc,"'.")
-    if(rstruc==1){# group specific
-      nr <- dim(dr)[2]
-      if((cstrucn[1] == 2) | (cstrucn[1] == 4)) {
-        if(is.null(dist) || NROW(dist)!=nr)
-          dist=matrix(1:nr)
-        if(NROW(dist)!=nr)
-          stop("Number of rows in 'dist' should be same as maximum number of groups when corWithin = FALSE")
+  if(!is.null(dr)){
+    nr <- table(factor(colnames(dr),levels=unique(colnames(dr))))
+    
+    if(is.null(dLV))dLV <- as(matrix(0), "TsparseMatrix")  
+    # distance matrix checks
+    if(any(cstruc%in%c("corExp","corMatern"))){
+      if(length(dist)!=sum(cstruc%in%c("corExp","corMatern"))){
+        stop("Number of provided distance matrices should equal the number of spatially structured row effects.")
+      }else{
+        if(!all(unlist(lapply(dist, nrow))==nr[cstruc%in%c("corExp","corMatern")])){
+          stop("Number of rows in 'dist' matrices should be same as number of units in the corresponding spatial row effect.")
+        }
       }
     }
-    if(rstruc==2) { # correlated within groups
-      if(is.null(dr)) stop("Define structure for row params if 'rstruc == 2'.")
-      nr <- dim(dr)[2]
-      times <- n/nr#dim(dr)[1]
-      if((cstrucn[1] == 2) | (cstrucn[1] == 4)) {
-        if(is.null(dist) || NROW(dist)!=times)
-          dist=matrix(1:times)
-        if(NROW(dist)!=times)
-          stop("Number of rows in 'dist' should be same as maximum number of units within groups when corWithin = TRUE")
-        
-      }
-    }
-    if((cstrucn[1] == 2) | (cstrucn[1] == 4)) {
+    if(any(cstruc%in%c("corExp","corMatern"))) {
       if(is.null(rangeP)) {
-        rangeP = AD1 = (apply(as.matrix(dist),2,max)-apply(as.matrix(dist),2,min))/scalmax
+        rangeP = AD1 = unlist(mapply("/", lapply(mapply('-', lapply(dist,function(x)apply(x,2,max)), lapply(dist,function(x)apply(x,2,min)), SIMPLIFY = FALSE), mean), scalmax, SIMPLIFY = FALSE))
       } else {
-        AD1 = rep(rangeP, ncol(dist))[1:ncol(dist)]
+        if(length(rangeP) >1 && length(rangeP) != sum(cstruc%in%c("corExp","corMatern"))){
+          stop("The length of rangeP should be equal to the number of correlated structured row effects, or of length one.")
+        }else if(length(rangeP)==1){
+          rangeP = AD1 <- rep(rangeP,sum(cstruc%in%c("corExp","corMatern")))
+        }else if(length(rangeP) == sum(cstruc%in%c("corExp","corMatern"))){
+          AD1 = rangeP
+        }
       }
-      scaledc<-log(AD1)
-      # AD1<-pmax(apply(as.matrix(dist),2,function(x) min(dist(unique(x), diag = FALSE))),1)
-      # md<-min(dist(as.matrix(dist)%*%diag(1/(AD1), length(AD1)), diag = FALSE))/2
-      # if(md>5) AD1=AD1*md
+      scaledc = lapply(AD1, log)
+      # AD1 = pmax(apply(as.matrix(dist),2,function(x) min(dist(unique(x), diag = FALSE))),1)
+      # md = min(dist(as.matrix(dist)%*%diag(1/(AD1), length(AD1)), diag = FALSE))/2
+      # if(md>5) AD1 = AD1*md
+      # scaledc = log(AD1)
       # if(!is.null(setMap$scaledc)) {
       #   if( (length(setMap$scaledc)!= NCOL(dist))) stop("setMap$scaledc must be a numeric vector and have length that is same as the number of columns in 'dist'.")
       #   scaledc[is.na(setMap$scaledc)]=0
       # }
     }
-    if(nr==1) Ar.struc = "diagonal"
+    # Ar.struc <- ifelse(nr==1, "diagonal", Ar.struc)
+  }else{
+    dr <- as(matrix(0), "TsparseMatrix")  
+    nr <- 0
   }
+  
   if(num.lv.cor > 0){#rstruc
-    dist<-as.matrix(dist)
-    if(is.null(dLV)) stop("Define structure for row params if 'rstruc == ",rstruc,"'.")
+    distLV<-as.matrix(distLV)
+    if(is.null(dLV)) stop("Define structure for LVs'.")
     # LVs correlated within groups
-    if(is.null(dLV)) stop("Define structure for row params if 'rstruc == 2'.")
+    if(is.null(dLV)) stop("Define structure for LVs.")
     nu <- dim(dLV)[2]
     times <- n/nu#dim(dLV)[1]
-    if((cstrucn[2] == 2) | (cstrucn[2] == 4)) {
-      if(corWithin){
-        if(is.null(dist))
-          dist=matrix(1:times)
-        if(NROW(dist)!=times)
-          stop("Number of rows in 'dist' should be same as maximum number of units within groups when corWithin = TRUE")
+    if((cstruclvn == 2) | (cstruclvn == 4)) {
+      if(corWithinLV){
+        if(is.null(distLV))
+          distLV=matrix(1:times)
+        if(NROW(distLV)!=times)
+          stop("Number of rows in 'distLV' should be same as maximum number of units within groups when corWithinLV = TRUE")
       } else {
-        if(is.null(dist))
-          dist=matrix(1:nu)
-        if(NROW(dist)!=nu)
-          stop("Number of rows in 'dist' should be same as maximum number of groups when corWithin = FALSE")
+        if(is.null(distLV))
+          distLV=matrix(1:nu)
+        if(NROW(distLV)!=nu)
+          stop("Number of rows in 'distLV' should be same as maximum number of groups when corWithinLV = FALSE")
       }
       if(is.null(rangeP)) {
-        rangeP = AD1 = (apply(as.matrix(dist),2,max)-apply(as.matrix(dist),2,min))/scalmax
+        rangeP = AD1 = (apply(as.matrix(distLV),2,max)-apply(as.matrix(distLV),2,min))/scalmax
       } else {
-        AD1 = rep(rangeP, ncol(dist))[1:ncol(dist)]
+        AD1 = rep(rangeP, ncol(distLV))[1:ncol(distLV)]
       }
       scaledc<-log(AD1)
     }
@@ -266,8 +268,6 @@ trait.TMB <- function(
   if(is.null(colnames(y))) colnames(y) <- paste("Col",1:p,sep="")
   if(!is.null(X)) { if(is.null(colnames(X))) colnames(X) <- paste("x",1:ncol(X),sep="") }
   
-
-
   if(family == "orderedBeta") {
     if (!(method %in% c("VA", "EVA"))) #"tweedie", 
       stop("family=\"", family, "\" : family not implemented with LA method, change the method to 'VA'")
@@ -361,15 +361,13 @@ trait.TMB <- function(
         B <- c(res$B)[1:ncol(Xd)]
         if(any(is.na(B))) B[is.na(B)] <- 0
       }
-      row.params <- NULL;
-      if(row.eff!=FALSE){
-        row.params <- res$row.params
-        if(rstruc==0 && row.eff=="random") row.params <- row.params[1:nr]#rstruc
-        if(rstruc==1 && row.eff=="random") try(row.params <- (t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)#rstruc
-        # if(rstruc<2 && row.eff=="random") row.params <- row.params[1:nr] #rstruc
-        if (row.eff == "random") {
-          sigma <- sd(row.params);
-        }
+      row.params <- NULL
+      if (start.params$row.eff != FALSE) {
+        row.params <- start.params$params$row.params
+        if(row.eff=="fixed")
+          row.params[1] <- 0
+        if(row.eff=="random")
+          sigma <- start.params$params$sigma
       }
       vameans <- theta <- lambda <- NULL
       
@@ -409,11 +407,11 @@ trait.TMB <- function(
         zero.cons <- which(theta == 0)
         if(num.lv.cor>0){ # In correlation model, 
           rho_lvc<- rep(0, num.lv.cor);
-          if((cstrucn[2] == 2) | (cstrucn[2] == 4)) {
+          if((cstruclv == 2) | (cstruclv == 4)) {
             if(is.null(rangeP)) {
-              rangeP = AD1 = (apply(as.matrix(dist),2,max)-apply(as.matrix(dist),2,min))/scalmax
+              rangeP = AD1 = (apply(as.matrix(distLV),2,max)-apply(as.matrix(distLV),2,min))/scalmax
             } else {
-              AD1 = rep(rangeP, ncol(dist))[1:ncol(dist)]
+              AD1 = rep(rangeP, ncol(distLV))[1:ncol(distLV)]
             }
             scaledc<-log(AD1)
           }
@@ -449,15 +447,14 @@ trait.TMB <- function(
         vameans <- theta <- lambda <- NULL
         
         row.params <- NULL
-        if(row.eff %in% c("fixed","random",TRUE)) {
-          if(row.eff == start.params$row.eff){ 
-            res$row.params <- row.params <- start.params$params$row.params
-            if(row.eff %in% c("random")) res$sigma <- sigma <- start.params$params$sigma
-          } else {
-            row.params <- res$row.params
+        if (row.eff != FALSE) {
+          row.params <- res$row.params
+          if (row.eff == "random") {
+            try(row.params <- (Matrix::t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)
+            sigma <- aggregate(as.matrix(row.params), by = list(row.names(row.params)), FUN = sd)[,2]
           }
-          
-        } 
+        }
+        
         sigma.lv <- 0
         if(num.lv > 0) {
           sigma.lv <- start.params$params$sigma.lv
@@ -475,17 +472,16 @@ trait.TMB <- function(
           }
         }
         if(num.lv.cor>0){ # sigmas are scale parameters # just diagonal values, not
-          if(is.numeric(start.params$params$rho.lv) & ((cstrucn[2] == 2) | (cstrucn[2] == 4))) {
-            # if(cstrucn[2] == 4) start.params$params$rho.lv <- start.params$params$rho.lv[,-ncol(start.params$params$rho.lv), drop=FALSE]
+          if(is.numeric(start.params$params$rho.lv) & ((cstruclv == 2) | (cstruclv == 4))) {
+            # if(cstruclv == 4) start.params$params$rho.lv <- start.params$params$rho.lv[,-ncol(start.params$params$rho.lv), drop=FALSE]
             scaledc = colMeans(as.matrix(start.params$params$rho.lv)); 
-            if(length(scaledc) < ncol(dist) ) scaledc <- rep(scaledc, ncol(dist))[1:ncol(dist)]
+            if(length(scaledc) < ncol(distLV) ) scaledc <- rep(scaledc, ncol(distLV))[1:ncol(distLV)]
           }
         }
         if(family == "negative.binomial" && start.params$family == "negative.binomial" && !is.null(start.params$params$phi)) {res$phi<-start.params$params$phi}
       } else { stop("Model which is set as starting parameters isn't the suitable you are trying to fit. Check that attributes y, X, TR and row.eff match to each other.");}
     }
     if (is.null(offset))  offset <- matrix(0, nrow = n, ncol = p)
-    
     
 ### Starting values for dispersion/shape parameters
     
@@ -497,7 +493,6 @@ trait.TMB <- function(
         phis[phis < 0.02] <- 0.02
       res$phi <- phis
       phis <- 1/phis
-      
     }
     if (family == "ZIP" && starting.val=="res") {
       phis <- res$phi
@@ -560,7 +555,7 @@ trait.TMB <- function(
     
 ### Jittering for row effs/random coefs
     if(jitter.var.r>0){ 
-      if(row.eff == "random") row.params <- row.params + rnorm(n, 0, sd = sqrt(jitter.var.r));
+      if(row.eff == "random") row.params <- row.params + rnorm(sum(nr), 0, sd = sqrt(jitter.var.r));
       if(!is.null(randomX)) Br <- Br + t(MASS::mvrnorm(p, rep(0, nrow(Br)),diag(nrow(Br))*jitter.var.r));
     }
     
@@ -590,10 +585,9 @@ trait.TMB <- function(
       if(family=="ZINB") res$ZINBphi <- ZINBphi
     }
     
+    nlvr=num.lv
     if(!is.null(row.params)){ r0 <- row.params} else {r0 <- rep(0, n)}
-    if(row.eff == "random" && rstruc ==0){ nlvr<-num.lv+1 } else {nlvr=num.lv}
     if(row.eff=="fixed"){xr <- matrix(1,1,p)} else {xr <- matrix(0,1,p)}
-    
     
     optr<-NULL
     timeo<-NULL
@@ -652,16 +646,16 @@ trait.TMB <- function(
     
     
     ## Set up starting values for scale (and shape) parameters for correlated LVs
-    if(num.lv.cor>0 & cstrucn[2]>0){
+    if(num.lv.cor>0 & cstruclv>0){
       rho_lvc<- matrix(rep(0, num.lv.cor))
-      if(cstrucn[2]==2){
+      if(cstruclv==2){
         if(is.null(rho.lv)) {
           rho.lv=rep(0, num.lv.cor) 
         } else if(length(rho.lv)==num.lv.cor) {
           rho.lv=c(log(rho.lv))
         }
         rho_lvc<- matrix(c(rep(scaledc, each=num.lv.cor)), num.lv.cor)
-      } else if(cstrucn[2]==4){
+      } else if(cstruclv==4){
         if(is.null(rho.lv)) {
           rho.lv=rep(log(MaternKappa), each=num.lv.cor)
         } else if(length(rho.lv)==num.lv.cor) {
@@ -674,16 +668,16 @@ trait.TMB <- function(
       #   map.list$scaledc = factor(rep(NA, length(scaledc)))
       # }
       
-      if(cstrucn[2] %in% c(2,4)){
+      if(cstruclv %in% c(2,4)){
         iv<-rep(1:nrow(rho_lvc), ncol(rho_lvc)); 
         if(!is.null(setMap$rho_lvc)){
           if((length(setMap$rho_lvc)==length(rho_lvc))) 
             iv = (setMap$rho_lvc)
           map.list$rho_lvc = factor(iv)
-        } else if(cstrucn[2]==2){ #cstruc=="corExp"
+        } else if(cstruclv==2){ #cstruc=="corExp"
           maprho = matrix(iv, nrow(rho_lvc), ncol(rho_lvc))
           map.list$rho_lvc = factor(c(maprho))
-        } else if(cstrucn[2]==4){
+        } else if(cstruclv==4){
           # Fix matern smoothness by default
           maprho = matrix(iv, nrow(rho_lvc), ncol(rho_lvc))
           maprho[, ncol(maprho)] = NA
@@ -723,7 +717,7 @@ trait.TMB <- function(
     
     # Variational covariances for structured/correlated LVs
     if((num.lv.cor>0) & (method %in% c("VA", "EVA"))){
-      if(corWithin) {
+      if(corWithinLV) {
         if(diag.iter>0){
           if(Astruc>=3){
             Au <- c(Au[1:(n)])
@@ -758,7 +752,7 @@ trait.TMB <- function(
             Au<-c(Au,AQ[lower.tri(AQ, diag = TRUE)])
           }
         } else {
-          if(Lambda.struc == "unstructured" && Astruc==1 & cstrucn[2]==0){
+          if(Lambda.struc == "unstructured" && Astruc==1 & cstruclv==0){
             Au <- c(Au[1:(nu*num.lv.cor)], rep(0, nu*num.lv.cor*(num.lv.cor-1)/2))
           } else  if(Astruc==1){
             Au <- c(Au[1:(nu*num.lv.cor)], rep(0, num.lv.cor*nu*(nu-1)/2) )
@@ -781,7 +775,7 @@ trait.TMB <- function(
           }
         }
       }
-      # if(corWithin) {
+      # if(corWithinLV) {
       #   if(Lambda.struc == "unstructured" && Astruc==1) {
       #     Au <- c(Au[1:(n*num.lv.cor)], rep(0,sum(lower.tri(matrix(0,n,n))[,1:2])*num.lv.cor) )
       #   } else if(Lambda.struc == "bdNN" && Astruc==2){
@@ -791,7 +785,7 @@ trait.TMB <- function(
       # } else {
       #   u <- as.matrix(u[1:nu,])
       #   Au <- Au[1:(nu*num.lv.cor)]
-      #   if(Lambda.struc == "unstructured" && Astruc==1 & cstrucn[2]==0 & diag.iter==0){
+      #   if(Lambda.struc == "unstructured" && Astruc==1 & cstruclv==0 & diag.iter==0){
       #     Au <- c(Au[1:(nu*num.lv.cor)], rep(0, nu*num.lv.cor*(num.lv.cor-1)/2))
       #   } else {
       #     Au <- Au[1:(nu*num.lv.cor)]
@@ -801,20 +795,10 @@ trait.TMB <- function(
       
     # Variational covariances for  random rows
     if(row.eff == "random"){
-      if(rstruc ==1){
-        lg_Ar <- rep(log(Lambda.start[2]), nr)
-      } else {
-        lg_Ar <- rep(log(Lambda.start[2]), n)
-      }
+      lg_Ar <- rep(log(Lambda.start[2]), sum(nr))
       
-      if(rstruc == 0 && nlvr>num.lv && (num.lv.cor==0) & (Ar.struc!="diagonal")){
-        lg_Ar<-c(lg_Ar, rep(0, num.lv*n))
-      }
-      if(rstruc == 1 & (cstrucn[1] %in% c(1,2,3,4)) & Ar.struc!="diagonal"){
-        lg_Ar<-c(lg_Ar, rep(0, nr*(nr-1)/2))
-      }
-      if(rstruc == 2 & Ar.struc!="diagonal"){
-        lg_Ar<-c(lg_Ar, rep(0, nr*times*(times-1)/2))
+      if(Ar.struc!="diagonal" && diag.iter == 0){
+        lg_Ar<-c(lg_Ar, rep(1e-3, sum(nr*(nr-1)/2)))
       }
     } else {lg_Ar <- 0}
     
@@ -863,43 +847,45 @@ trait.TMB <- function(
       map.list$sigmaLV = factor(NA)
     }
     if(num.lv.cor>0){
-      if(!corWithin) {
+      if(!corWithinLV) {
         if(nrow(u) != nu){
           u=as.matrix((t(dLV)%*%u/colSums(dLV))[1:nu,, drop=FALSE])
         }
       }
     }
 
-    ## Row effect settings
-    if(row.eff=="random"){
-      randoml[1] <- 1
-      randomp <- c(randomp,"r0")
-      
-      if(dependent.row && (rstruc == 0)) 
-        sigma<-c(sigma[1], rep(0, num.lv))
-      if((rstruc %in% 1:2)) {
-        if(cstrucn[1] %in% c(1,3)) {
-          sigma = c(log(sigma[1]),0)
-        } else if(cstrucn[1] %in% c(2)){
-          sigma = c(log(sigma[1]),scaledc)
-          if(is.null(setMap$log_sigma)) map.list$log_sigma = factor( c(1, rep(2,length(sigma)-1) ) )
-        } else if(cstrucn[1] %in% c(4)){
-          sigma = c(log(sigma[1]),scaledc)
-          # Fix matern smoothness by default
-          if(is.null(setMap$log_sigma)) map.list$log_sigma = factor( c(1, rep(2,length(sigma)-1), NA) )
-          sigma = c(sigma,log(MaternKappa))
-        } else {
-          sigma = c(log(sigma[1]))
+      ## Row effect settings
+      if(row.eff=="random"){
+        randoml[1] <- 1
+        randomp <- c(randomp,"r0")
+        sigmanew <- map.list$log_sigma <- NULL
+        iter = 1 # keep track of # spatial structures
+        for(re in cstrucn){
+          if(re %in% c(1,3)) {
+            sigmanew = c(sigmanew, log(sigma[1]),0)
+            if(is.null(setMap$log_sigma) && any(cstrucn%in%c(4)))map.list$log_sigma <- c(map.list$log_sigma, max(map.list$log_sigma, na.rm = TRUE)+1, max(map.list$log_sigma, na.rm = TRUE)+2)
+          } else if(re %in% c(2)){
+            sigmanew = c(sigmanew, log(sigma[1]),scaledc[[iter]])
+            iter <- iter + 1
+            if(is.null(setMap$log_sigma) && any(cstrucn%in%c(4)))map.list$log_sigma <- c(map.list$log_sigma, max(map.list$log_sigma, na.rm = TRUE)+1, max(map.list$log_sigma, na.rm = TRUE)+2)
+          } else if(re %in% c(4)){
+            sigmanew = c(sigmanew, log(sigma[1]),scaledc[[iter]])
+            iter <- iter + 1
+            # Fix matern smoothness by default
+            if(is.null(setMap$log_sigma) && any(cstrucn%in%c(4)))map.list$log_sigma <- c(map.list$log_sigma, max(map.list$log_sigma, na.rm = TRUE)+1, max(map.list$log_sigma, na.rm = TRUE)+2, NA)
+            sigmanew = c(sigmanew, sigma,log(MaternKappa))
+          } else {
+            if(is.null(setMap$log_sigma) && any(cstrucn%in%c(4)))map.list$log_sigma <- c(map.list$log_sigma, max(map.list$log_sigma, na.rm = TRUE)+1)
+            sigmanew = c(sigmanew, log(sigma[1]))
+          }
         }
+        sigma <- sigmanew
+      } else {
+        sigma=0
+        map.list$log_sigma <- factor(NA)
+        map.list$lg_Ar <- factor(NA)
+        # if(row.eff != "fixed") map.list$r0 <- factor(rep(NA, length(r0)))
       }
-      
-
-    } else {
-      sigma=0
-      map.list$log_sigma <- factor(NA)
-      map.list$lg_Ar <- factor(NA)
-      # if(row.eff != "fixed") map.list$r0 <- factor(NA, length(r0))
-    }
     
     # Random slopes
     if(!is.null(randomX)){
@@ -982,7 +968,7 @@ trait.TMB <- function(
       parameter.list = list(r0=matrix(r0), b = rbind(a), b_lv = matrix(0), sigmab_lv = 0, Ab_lv = 0, B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, bH=bH, thetaH = thetaH
 
       objr <- TMB::MakeADFun(
-        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, family=familyn, extra=extra, quadratic = 1, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, Astruc=Astruc, NN = NN, Ntrials = Ntrials), silent=!trace,
+        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, family=familyn, extra=extra, quadratic = 1, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials), silent=!trace,
         parameters = parameter.list, map = map.list2,
         inner.control=list(mgcmax = 1e+200),
         DLL = "gllvm")
@@ -1008,7 +994,7 @@ trait.TMB <- function(
       parameter.list = list(r0=matrix(r0), b = rbind(a),  b_lv = matrix(0), sigmab_lv = 0, Ab_lv = 0, B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, bH=bH, thetaH = thetaH
 
       objr <- TMB::MakeADFun(
-        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, Astruc=Astruc, NN = NN, Ntrials = Ntrials), silent=!trace,
+        data = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials), silent=!trace,
         parameters = parameter.list, map = map.list,
         inner.control=list(mgcmax = 1e+200),
         DLL = "gllvm")
@@ -1018,7 +1004,7 @@ trait.TMB <- function(
       map.list$Au <- map.list$Abb <- map.list$lg_Ar <- factor(NA)
       
       parameter.list = list(r0=matrix(r0), b = rbind(a), b_lv = matrix(0), sigmab_lv = 0, Ab_lv = 0, B=matrix(B), Br=Br, lambda = theta, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi), sigmaB=log(sqrt(diag(sigmaB))), sigmaij=sigmaij, log_sigma=c(sigma), rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, thetaH = thetaH, bH=bH
-      data.list <- list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = 0, family=familyn,extra=extra,method=1,model=1,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
+      data.list <- list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = 0, family=familyn,extra=extra,method=1,model=1,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
 
       if(family == "ordinal"){
         data.list$method = 0
@@ -1046,7 +1032,7 @@ trait.TMB <- function(
     
     ### Now diag.iter, improves the model fit sometimes
     
-    if(diag.iter>0 && !(Lambda.struc %in% c("diagonal", "diagU")) && (method %in% c("VA", "EVA")) && (num.lv>1 || !is.null(randomX)) && !inherits(optr,"try-error")){
+    if(diag.iter>0 && (!(Lambda.struc %in% c("diagonal", "diagU")) && (method %in% c("VA", "EVA")) && (num.lv>1 || !is.null(randomX)) && !inherits(optr,"try-error") | (row.eff=="random" & Ar.struc=="unstructured"))){
       objr1 <- objr
       optr1 <- optr
       param1 <- optr$par
@@ -1078,13 +1064,13 @@ trait.TMB <- function(
           lambda2 <- matrix(param1[nam == "lambda2"], byrow = T, ncol = num.lv, nrow = p)
         }
         
-      } else {u1 <- u}
+      } else {u1 <- u;lambda1<-lambda}
       if((num.lv)>0){sigma.lv1 <- param1[nam=="sigmaLV"]}else{sigma.lv1<-0}
 
       
       if(num.lv.cor>0){
         Au1<- c(param1[nam=="Au"])
-        if(corWithin) {
+        if(corWithinLV) {
           if(Lambda.struc == "unstructured" && Astruc==1) {
             Au1 <- c(pmax(Au1[1:(n*num.lv.cor)],log(1e-2)), rep(1e-3,sum(lower.tri(matrix(0,n,n)))*num.lv.cor) )
           } else if(Lambda.struc == "bdNN" && Astruc==2){
@@ -1095,7 +1081,7 @@ trait.TMB <- function(
             Au1 <- c(log(exp(Au1[1:(n)])+1e-2), rep(1e-3,nrow(NN)*nu), Au1[-(1:n)])
           }
         } else {
-          if(Lambda.struc == "unstructured" && Astruc==1 & cstrucn[2]==0){
+          if(Lambda.struc == "unstructured" && Astruc==1 & cstruclv==0){
             Au1 <- c(pmax(Au1[1:(nu*num.lv.cor)],log(1e-2)), rep(1e-3, nu*num.lv.cor*(num.lv.cor-1)/2))
           } else  if(Astruc==1){
             Au1 <- c(pmax(Au1[1:(nu*num.lv.cor)],log(1e-2)), rep(1e-3, num.lv.cor*nu*(nu-1)/2) )
@@ -1108,8 +1094,8 @@ trait.TMB <- function(
           }
           
         }
-        if(cstrucn[2]>0){
-          if(cstrucn[2] %in% c(2,4)){ #cstruc=="corExp" || cstruc=="corMatern"
+        if(cstruclv>0){
+          if(cstruclv %in% c(2,4)){ #cstruc=="corExp" || cstruc=="corMatern"
             if(num.lv.cor>0){
               rho_lvc <- matrix((param1[nam=="rho_lvc"])[map.list$rho_lvc],nrow(rho_lvc),ncol(rho_lvc)); 
               rho_lvc[is.na(rho_lvc)]=0 
@@ -1127,9 +1113,12 @@ trait.TMB <- function(
       if(family=="ZINB"){lg_phiZINB1 <- param1[nam=="lg_phiZINB"][disp.group]}else{lg_phiZINB1<-log(ZINBphi)}
       if(family=="tweedie" && is.null(Power))ePower = param1[nam == "ePower"]
       if(row.eff == "random"){
-        log_sigma1 <- log(exp(param1[nam=="log_sigma"])+1e-3)
+        log_sigma1 <- ifelse(param1[nam=="log_sigma"]==0,1e-3,param1[nam=="log_sigma"])
         if(!is.null(map.list$log_sigma)) log_sigma1 = log_sigma1[map.list$log_sigma]
-        lg_Ar<- log(exp(param1[nam=="lg_Ar"])+1e-3)
+        lg_Ar<- log(exp(param1[nam=="lg_Ar"][1:sum(nr)])+1e-3)
+        if(Ar.struc=="unstructured"){
+          lg_Ar <- c(lg_Ar, rep(1e-3, sum(nr*(nr-1)/2)))
+        }
       } else {log_sigma1 = 0}
 
       if(family %in% c("ordinal")){
@@ -1141,7 +1130,7 @@ trait.TMB <- function(
       }
       parameter.list = list(r0=r1, b = b1, b_lv = matrix(0), sigmab_lv = 0, Ab_lv = 0, B=B1, Br=Br1, lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1, lg_phi=lg_phi1, sigmaB=sigmaB1, sigmaij=sigmaij1, log_sigma=log_sigma1, rho_lvc=rho_lvc, Au=Au1, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta, ePower = ePower, lg_phiZINB = lg_phiZINB1) #, scaledc=scaledc, thetaH = thetaH, bH=bH
 
-      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE&num.lv>0,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
+      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE&num.lv>0,1,0), family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
 
       objr <- TMB::MakeADFun(
         data = data.list, silent=!trace,
@@ -1201,7 +1190,7 @@ trait.TMB <- function(
       
         parameter.list = list(r0=r1, b = b1, b_lv = matrix(0), sigmab_lv = 0, Ab_lv = 0, B=B1, Br=Br1, lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1, lg_phi=lg_phi1, sigmaB=sigmaB1, sigmaij=sigmaij1, log_sigma=log_sigma1, rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, Abb=Abb, zeta=zeta, ePower = ePower, lg_phiZINB = lg_phiZINB1) #, scaledc=scaledc, thetaH = thetaH, bH=bH
 
-      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 1, family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), rstruc = rstruc, times = times, cstruc=cstrucn, dc=dist, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
+      data.list = list(y = y, x = Xd, x_lv = matrix(0), xr=xr, xb=xb, dr0 = dr, dLV = dLV, offset=offset, num_lv = num.lv, num_RR = 0, num_lv_c = 0, quadratic = 1, family=familyn, extra=extra, method=switch(method, VA=0, EVA=2), model=1, random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLv, Astruc=Astruc, NN = NN, Ntrials = Ntrials)
 
       objr <- TMB::MakeADFun(
         data = data.list, silent=!trace,
@@ -1282,7 +1271,7 @@ trait.TMB <- function(
     ui<-names(param)=="u"
     
     if(num.lv.cor > 0){ # Correlated latent variables
-      if(corWithin){
+      if(corWithinLV){
         lvs<-(matrix(param[ui],n,num.lv.cor))
       } else {
         lvs = matrix(param[ui],nu,num.lv.cor)
@@ -1303,8 +1292,8 @@ trait.TMB <- function(
         theta <- as.matrix(1)
       }
       rho_lvc = param[names(param)=="rho_lvc"]
-      if((cstrucn[2] %in% c(1,3))) rho.lv<- param[names(param)=="rho_lvc"] / sqrt(1.0 + param[names(param)=="rho_lvc"]^2);
-      if((cstrucn[2] %in% c(2,4))){ 
+      if((cstruclv %in% c(1,3))) rho.lv<- param[names(param)=="rho_lvc"] / sqrt(1.0 + param[names(param)=="rho_lvc"]^2);
+      if((cstruclv %in% c(2,4))){ 
         rho.lv<- exp(param[names(param)=="rho_lvc"]);
         # scaledc<- exp(param[names(param)=="scaledc"]);
       }
@@ -1324,17 +1313,13 @@ trait.TMB <- function(
     }
     
     if(row.eff!=FALSE) {
-      ri = names(param)=="r0"
-      row.params = param[ri] 
+      ri <- names(param)=="r0"
+      row.params=param[ri]
       if(row.eff=="random"){
-        sigma = exp(param[names(param)=="log_sigma"])[1]
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn[1] %in% c(1,3))) rho = param[names(param)=="log_sigma"][2] / sqrt(1.0 + param[names(param)=="log_sigma"][2]^2);
-        if((rstruc ==2 | (rstruc == 1)) & (cstrucn[1] %in% c(2,4))) {
-          rho = exp(param[names(param)=="log_sigma"][-1]);
-        }
-        if(num.lv>0 && dependent.row && rstruc==0) sigma = c(sigma, (param[names(param)=="log_sigma"])[-1])
+        sigma<-param[names(param)=="log_sigma"]
       }
     }
+    
     if(!is.null(randomX)){
       Bri <- names(param)=="Br"
       Br <- matrix(param[Bri],ncol(xb),p)
@@ -1425,24 +1410,51 @@ trait.TMB <- function(
       
       # row params
       if(row.eff!=FALSE) {
-        if(row.eff=="random"){  
-          out$params$sigma <- sigma; 
-          names(out$params$sigma) <- "sigma"
-          if((rstruc ==2 | (rstruc == 1)) & (cstrucn[1] %in% c(1,2,3,4))){
-            out$params$rho <- rho
-            names(out$params$rho)="rho"
+        if(row.eff=="random"){ 
+          out$dr=dr
+          iter = 1 # keep track of index
+          for(re in 1:length(cstrucn)){
+            if(cstrucn[re] %in% c(1,3)) {
+              sigma[iter] <- exp(sigma[iter])
+              names(sigma)[iter] = names(nr)[re]
+              names(sigma)[iter+1] = paste0(names(nr)[re],"rho")
+              sigma[iter+1] <- sigma[iter+1] / sqrt(1.0 + sigma[iter+1]^2);
+              iter <- iter +2
+            } else if(cstrucn[re] %in% c(2)){
+              sigma[iter] <- exp(sigma[iter:(iter+1)])
+              names(sigma)[iter] = "Scale"
+              names(sigma)[iter+1] = names(nr)[re]
+              iter <- iter + 2
+            } else if(cstrucn[re] %in% c(4)){
+              sigma[iter] <- exp(sigma[iter:(iter+2)])
+              names(sigma)[iter] = "Scale"
+              names(sigma)[iter+1] = names(nr)[re]
+              iter <- iter + 2
+              # Matern smoothness
+              names(sigma)[iter+1] = "Matern kappa"
+              iter <- iter +1
+            } else {
+              names(sigma)[iter] = names(nr)[re]
+              iter <- iter +1
+            }
           }
-          if(num.lv>0 && dependent.row) names(out$params$sigma) <- paste("sigma",c("",1:num.lv), sep = "")
+          out$params$sigma=sigma; 
+          
+          # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,2,3,4))){ 
+          #   out$params$rho <- rho
+          #   names(out$params$rho)="rho"
+          #   # if(cstrucn %in% c(2,4)){ out$params$scaledc=scaledc}
+          # }
+          # if((num.lv+num.lv.c)>1 && dependent.row) names(out$params$sigma) <- paste("sigma",c("",1:(num.lv+num.lv.c)), sep = "")
         }
         out$params$row.params <- row.params; 
-        if(length(row.params) == n) names(out$params$row.params) <- rownames(out$y)
-        if((length(row.params) == ncol(dr)) && (rstruc==1)) try(names(out$params$row.params) <- colnames(dr), silent = TRUE)
+        try(names(out$params$row.params) <- colnames(dr), silent = TRUE)
       }
       
       # LV correlation matrix parameters
-      if(num.lv.cor>0 & cstrucn[2]>0){
+      if(num.lv.cor>0 & cstruclv>0){
         out$params$rho.lv <- rho.lv; 
-        if(cstrucn[2] %in% c(2,4)){ 
+        if(cstruclv %in% c(2,4)){ 
           names(out$params$rho.lv) <- paste("rho.lv",1:length(out$params$rho.lv), sep = "") #[!is.na(map.list$sigma_lvc)]
         } else {
           names(out$params$rho.lv) <- paste("rho.lv",1:num.lv.cor, sep = "") 
@@ -1515,11 +1527,11 @@ trait.TMB <- function(
       if((method %in% c("VA", "EVA"))){
         param <- objr$env$last.par.best
         
-        if(num.lv.cor>0 && !corWithin){
+        if(num.lv.cor>0 && !corWithinLV){
           Au <- param[names(param)=="Au"]
           AQ <- NULL
           
-          if(cstrucn[2]==0){
+          if(cstruclv==0){
             A <- array(0, dim=c(nu, num.lv.cor, num.lv.cor))
             for (d in 1:(num.lv.cor)){
               for(i in 1:nu){
@@ -1599,7 +1611,7 @@ trait.TMB <- function(
           out$A <- A
           out$AQ <- AQ
           
-        } else if(num.lv.cor>0 && corWithin){
+        } else if(num.lv.cor>0 && corWithinLV){
           Au <- param[names(param)=="Au"]
           if(Astruc<3){ 
             nMax<- num.lv.cor
@@ -1632,19 +1644,7 @@ trait.TMB <- function(
         } else if(nlvr>0){
           param <- objr$env$last.par.best
           A <- array(0, dim=c(n, nlvr, nlvr))
-          if(nlvr>num.lv){
-            lg_Ar <- param[names(param)=="lg_Ar"]
-            for(i in 1:n){
-              A[i,1,1]=exp(lg_Ar[i]);
-            }
-            if(length(lg_Ar)>n){
-              for (r in 2:nlvr){
-                for(i in 1:n){
-                  A[i,r,1]=lg_Ar[((r-1)*n+i)];
-                }}
-            }
-          }
-          
+ 
           if(num.lv>0){
             Au <- param[names(param)=="Au"]
             for (d in 1:num.lv){
@@ -1674,49 +1674,30 @@ trait.TMB <- function(
           }
         }
         
-        if(num.lv == nlvr && row.eff=="random"){
+        if(row.eff=="random"){
           lg_Ar <- param[names(param)=="lg_Ar"]
-          Ar <- exp((lg_Ar)[1:length(out$params$row.params)])
-          out$Ar <- Ar
-          if(rstruc == 1 && cstrucn[1]>0){
-            Arm <- matrix(0,nr,nr)
-            diag(Arm)<-Ar
-            if(length(lg_Ar)>nr){
-              k=0;
-              for(d in 1:nr){
-                r <- d + 1;
-                while (r <= nr){
-                  Arm[r,d] = lg_Ar[nr+k];
-                  k=k+1; r=r+1;
-                }}
-            }
-            Arm <- Arm %*% t(Arm)
-            out$Ar <- diag(Arm)
+          Ar <- vector("list", length(nr))
+          Ar.sds <- exp((lg_Ar)[1:sum(nr)])
+          lg_Ar <- lg_Ar[-c(1:sum(nr))]
+          for(re in 1:length(nr)){
+            Ar[[re]] <- diag(Ar.sds[1:nr[re]])
           }
-          if(rstruc == 2){
-            
-            Arm <- array(0, dim = c(times,times,nr));
-            for(i in 1:nr){
-              for(d in 1:times){
-                Arm[d,d,i]=Ar[(i-1)*times+d];
+          if(Ar.struc == "unstructured"){
+            if(length(lg_Ar)>0){
+              k=1;
+              for(re in 1:length(nr)){
+                for(d in 1:(nr[re]-1)){
+                  for(r in (d+1):nr[re]){
+                    Ar[[re]][r,d] = lg_Ar[k];
+                    k=k+1;
+                  }}
               }
             }
-            if(length(lg_Ar)>(nr*times)){
-              k=0;
-              for(d in 1:times){
-                r <- d + 1;
-                while (r <= times){
-                  for(i in 1:nr){
-                    Arm[r,d,i]=lg_Ar[nr*times+k*nr+i];
-                  }
-                  k=k+1; r=r+1;
-                }}
-            }
-            for (i in 1:nr) {
-              Arm[,,i] <- Arm[,,i] %*% t(Arm[,,i])
-            }
-            out$Ar <- c(apply(Arm,3,diag))
           }
+          for(re in 1:length(nr)){
+            Ar[[re]] <- Ar[[re]]%*%t(Ar[[re]])
+          }
+          out$Ar <- Ar
         }
       }
       

--- a/R/confint.gllvm.R
+++ b/R/confint.gllvm.R
@@ -161,7 +161,7 @@ confint.gllvm <- function(object, parm=NULL, level = 0.95, ...) {
       cal <- cal + n
     }
     if (object$row.eff == "random") {
-      rnames[(cal + 1)] <- "sigma"
+      rnames[(cal + 1):(cal+length(object$sd$sigma))] <- "sigma"
       cal <- cal + length(object$sd$sigma)
       # if(!is.null(object$params$rho)) {
       #   rnames[(cal + 1)] <- "rho"

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -206,6 +206,7 @@
 #'    \item{Xcoef }{ coefficients related to environmental covariates X}
 #'    \item{B }{ coefficients in fourth corner model}
 #'    \item{row.params }{ row-specific intercepts}
+#'    \item{sigma }{ scale parameters for row-specific random effects}
 #'    \item{phi }{ dispersion parameters \eqn{\phi} for negative binomial or Tweedie family, probability of zero inflation for ZIP family, standard deviation for gaussian family or shape parameter for gamma/beta family}
 #'    \item{inv.phi }{ dispersion parameters \eqn{1/\phi} for negative binomial}
 #'    }}

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -337,8 +337,8 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       if (row.eff != FALSE) {
         row.params <- fit$row.params
-        if(row.eff=="random") try(row.params <- (Matrix::t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)
         if (row.eff == "random") {
+          try(row.params <- (Matrix::t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)
           sigma <- aggregate(as.matrix(row.params), by = list(row.names(row.params)), FUN = sd)[,2]
         }
       }#rep(0,n)
@@ -1293,7 +1293,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         ri = names(param)=="r0"
         row.params = param[ri]#c(0,param[ri])
         if(row.eff=="random"){
-          sigma = exp(param[names(param)=="log_sigma"])
+          sigma = param[names(param)=="log_sigma"]
           # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) rho = param[names(param)=="log_sigma"][2] / sqrt(1.0 + param[names(param)=="log_sigma"][2]^2);
           # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {
           #   rho = exp(param[names(param)=="log_sigma"][-1]);
@@ -1952,6 +1952,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
               names(sigma)[iter+1] = "Matern kappa"
               iter <- iter +1
             } else {
+              sigma[iter] <- exp(sigma[iter])
               names(sigma)[iter] = names(nr)[re]
               iter <- iter +1
             }

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -47,7 +47,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   # if(rstruc==0){ # No structure
   #   dr <- diag(n)
   # }
-  if(num.lv.cor==0){ # No structure
+  if(num.lv.cor==0 || is.null(dLV)){ # No structure
     dLV <- as(diag(n), "TsparseMatrix")
   }
   
@@ -59,8 +59,6 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   rho.lv =NULL  
   if(!is.null(dr)){
     nr <- table(factor(colnames(dr),levels=unique(colnames(dr))))
-
-  if(is.null(dLV))dLV <- as(matrix(0), "TsparseMatrix")  
     # distance matrix checks
       if(any(cstruc%in%c("corExp","corMatern"))){
         if(length(dist)!=sum(cstruc%in%c("corExp","corMatern"))){
@@ -95,8 +93,10 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       }
       # Ar.struc <- ifelse(nr==1, "diagonal", Ar.struc)
   }else{
-    dr <- as(matrix(0), "TsparseMatrix")  
-    nr <- 0
+    dr <- as(diag(n), "TsparseMatrix")  
+    dimnames(dr) <- list(rep("site", n), rep("site", n))
+    nr <- n
+    names(nr) = "site"
   }
 
   if(num.lv.cor > 0){#rstruc

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -2378,7 +2378,7 @@ sdrandom<-function(obj, Vtheta, incl, ignore.u = FALSE,return.covb = FALSE, type
   }
   r <- obj$env$random
   par = obj$env$last.par.best
-  
+  nr = obj$env$data$nr
   num.lv <- obj$env$data$num_lv
   num.lv.c <- obj$env$data$num_lv_c
   num.RR <- obj$env$data$num_RR
@@ -2543,12 +2543,16 @@ sdrandom<-function(obj, Vtheta, incl, ignore.u = FALSE,return.covb = FALSE, type
   out <- list()
   
   #separate errors row-effects
-  ser0 <- diag(covb[colnames(covb)=="r0",colnames(covb)=="r0"])
+  ser0 <- covb[colnames(covb)=="r0",colnames(covb)=="r0"]
   covb <- covb[colnames(covb)!="r0",colnames(covb)!="r0"]
   
   if(random[1] >0) {
-    CovRow <- matrix(ser0); 
-    out$row <- CovRow
+      Ar <- list()
+      for(re in 1:length(nr)){
+        Ar[[re]] <- ser0[1:nr[re],1:nr[re]]
+        ser0 <- ser0[-c(1:nr[re]),-c(1:nr[re])]
+      }
+    out$row <- Ar
   }
   seb_lv <- diag(covb[colnames(covb)=="b_lv",colnames(covb)=="b_lv"])
   
@@ -2723,6 +2727,7 @@ CMSEPf <- function(fit, return.covb = F, type = NULL){
   
   n<-nrow(fit$y)
   p<-ncol(fit$y)
+  nr <- model$TMBfn$env$data$nr
   num.lv <- fit$num.lv
   num.lv.c <- fit$num.lv.c
   num.RR <- fit$num.RR
@@ -2840,13 +2845,17 @@ CMSEPf <- function(fit, return.covb = F, type = NULL){
   colnames(covb)<-row.names(covb)<-colnames(D)
   
   #separate errors row-effects
-  ser0 <- diag(covb[colnames(covb)=="r0",colnames(covb)=="r0"])
+  ser0 <- covb[colnames(covb)=="r0",colnames(covb)=="r0"]
   covb <- covb[colnames(covb)!="r0",colnames(covb)!="r0"]
   
   out <- list()
   if(fit$row.eff == "random") {
-    CovArerr <- matrix(ser0); 
-    out$Ar <- CovArerr
+    Ar <- list()
+    for(re in 1:length(nr)){
+      Ar[[re]] <- ser0[1:nr[re],1:nr[re]]
+      ser0 <- ser0[-c(1:nr[re]),-c(1:nr[re])]
+    }
+    out$Ar <- Ar
   }
   
   #separate errors b_lv

--- a/R/gllvm.makeform.R
+++ b/R/gllvm.makeform.R
@@ -99,6 +99,14 @@ subbars1<-function (term)
     term[[1]] <- as.name("+")
   if (is.call(term) && term[[1]] == as.name("||")) 
     term[[1]] <- as.name("+")
+  if (is.call(term) && term[[1]] == as.name("/")){
+    term2<<-term
+    # stopifnot(lenght(term) >= )
+  }
+    # term <- append(term, term2[[1]])
+    # 
+    # append(term, as.name(paste0("(1|+",all.vars(term)[1],))
+    # term <- append(term, as.name(paste0("+(1|",paste0(terms(term[[1]]),collapse=":"))))
   for (j in 2:length(term)) {
     term[[j]] <- subbars1(term[[j]])
   }
@@ -143,7 +151,7 @@ mkReTrms1 <- function (bars, fr)
   Zt <- do.call(rbind, Ztlist)
   names(Ztlist) <- term.names
   
-  ll <- list(Zt = Zt)
+  ll <- list(Zt = Zt, nl = nl)
   ll
 }
 

--- a/R/ordiplot.gllvm.R
+++ b/R/ordiplot.gllvm.R
@@ -329,11 +329,7 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         } else {
 
           sdb<-CMSEPf(object, type = type)$A
-          
-          if((object$row.eff=="random") && (object$num.lv.c+object$num.lv)>0 && (dim(object$A)[2]>(object$num.lv.c+object$num.lv)) & (object$num.lvcor==0)){
-            object$A<- object$A[,-1,-1]
-          }
-          
+
           #If not marginal add variational covariances
           if(type!="residual"){
             #variational covariances but add 0s for RRR
@@ -457,10 +453,6 @@ ordiplot.gllvm <- function(object, biplot = FALSE, ind.spp = NULL, alpha = 0.5, 
         } else {
 
           sdb<-CMSEPf(object, type = type)$A
-          
-          if((object$row.eff=="random") && (object$num.lv.c+object$num.lv)>0  && (dim(object$A)[2]>(object$num.lv.c+object$num.lv)) & (object$num.lvcor==0)){
-            object$A<- object$A[,-1,-1]
-          }
           
           #If not marginal add variational covariances
           if(type!="residual" & (object$num.lvcor == 0) ){

--- a/R/predict.gllvm.R
+++ b/R/predict.gllvm.R
@@ -84,9 +84,7 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
       if(all.vars(object$call$row.eff) %in% colnames(newX)) {
         warning("Using row effects for predicting new sites does not work yet.")
       }
-    } else if ((length(object$params$row.params) != nrow(object$y)) & is.null(newX)) 
-      object$params$row.params = c(object$TMBfn$env$data$dr0 %*% 
-                                     object$params$row.params)
+    }
   }
   b0 <- object$params$beta0
   eta <- matrix(b0, n, p, byrow = TRUE)
@@ -308,13 +306,11 @@ predict.gllvm <- function(object, newX = NULL, newTR = NULL, newLV = NULL, type 
   
   if ((object$row.eff %in% c("random", "fixed", "TRUE")) && is.null(r0) & is.null(newX)) {
     if(!is.null(object$params$row.params)){
-      if(length(object$params$row.params)!=n) object$params$row.params = c(object$TMBfn$env$data$dr0%*%object$params$row.params) # !!!
+     object$params$row.params = object$TMBfn$env$data$dr0%*%object$params$row.params # !!!
     }
-    if(nrow(eta) == length(object$params$row.params)){
     r0 <- object$params$row.params
     if((object$row.eff %in% "random") && (level==0)) r0 = r0*0
-    eta <- eta + r0
-    }
+    eta <- eta + r0%*%rep(1,ncol(model$y))
   }
 
   if(!is.null(object$offset)){

--- a/src/gllvm.cpp
+++ b/src/gllvm.cpp
@@ -331,6 +331,8 @@ Type objective_function<Type>::operator() ()
         Adiag = Atemp.diagonal();
         nll -= Adiag.log().sum() - 0.5*((Atemp*Atemp.transpose()).trace()+(u.row(i)*u.row(i).transpose()).sum());
       }
+      nll -= 0.5*n*nlvr;
+      
       //scale LVs with standard deviations, as well as the VA covariance matrices
       u *= Delta;
       

--- a/src/gllvm.cpp
+++ b/src/gllvm.cpp
@@ -641,11 +641,10 @@ Type objective_function<Type>::operator() ()
       }
       }
       // add terms to cQ
-
-      for (int j=0; j<p;j++){
-        cQ.col(j) += 0.5*(dr0*ArmSP*Eigen::VectorXd::Ones(nr.sum()));
+      for (int i=0; i<n;i++){
+        cQ.row(i) += 0.5*(dr0.row(i)*ArmSP*dr0.row(i).transpose())*Eigen::MatrixXd::Ones(1,p);
       }
-
+      REPORT(cQ);
       REPORT(Arm);
       REPORT(ArmSP);
 
@@ -716,9 +715,10 @@ Type objective_function<Type>::operator() ()
       for(int i=0; i<nr.sum(); i++){
         SrIArmSPtrace += SrIArmSP.coeffRef(i,i);
       }
-      nll -= 0.5*vector<Type>(Armldlt.vectorD()).log().sum() - 0.5*(SrIArmSPtrace+(r0.transpose()*(SrI*r0)).sum());
+
+      nll -= 0.5*vector<Type>(Armldlt.vectorD()).cwiseAbs().log().sum() - 0.5*(SrIArmSPtrace+(r0.transpose()*(SrI*r0)).sum());
       // determinants of each block of the covariance matrix
-      nll -= 0.5*(nr.sum()-vector<Type>(Srldlt.vectorD()).log().sum());
+      nll -= 0.5*(nr.sum()-vector<Type>(Srldlt.vectorD()).cwiseAbs().log().sum());
       REPORT(SrI);
       REPORT(SrSP);
       REPORT(SrIArmSP);

--- a/src/gllvm.cpp
+++ b/src/gllvm.cpp
@@ -649,6 +649,7 @@ Type objective_function<Type>::operator() ()
       REPORT(ArmSP);
 
       // Three: we build the actual covariance matrix
+      // This can straightforwardly be extended to estimate correlation betwee effects
       Eigen::SparseMatrix<Type>SrSP(nr.sum(), nr.sum());
       SrSP.setZero();
       vector<matrix<Type>> Sr(nr.size());
@@ -661,7 +662,7 @@ Type objective_function<Type>::operator() ()
 
         // diagonal row effect
         if(cstruc(re) == 0){
-        Sr(re).diagonal().array() = sigma(sigmacounter);
+        Sr(re).diagonal().array() = pow(sigma(sigmacounter), 2);
         sigmacounter++;
         }else if(cstruc(re) == 1){ // corAR1
         Sr(re) = gllvm::corAR1(sigma(sigmacounter), log_sigma(sigmacounter+1), nr(re));
@@ -688,7 +689,7 @@ Type objective_function<Type>::operator() ()
         }
 
         // we do not want the cholesky of these matrices here, so need to store the square of each matrix
-        Sr(re) *= Sr(re).transpose();
+        // Sr(re) *= Sr(re).transpose();
 
         // This will facilitate things if at a later time we want correlation between effects too
         // SrSP is our sparse covariance matrix across all REs


### PR DESCRIPTION
PR that makes it possible to use multiple independent row-effects (i.e., crossed/nested and those with structures) in gllvm.

I sacrificed the "dependent.row" option to do this.

VA covariances are over the levels of the random effect now, and independent from the VA covariances for the latent variables. This is in to facilitate extending functionality in the future for correlation between multiple random intercepts.