### PR TITLE
Row effects update, and formula for traitTMB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+Version 1.4.9
+=============
+
+* Row.eff can now be used for community-level (species-common) effect
+* Both fixed and random at the same time (i.e., a mixed effects formula)
+  * Does not allow for a single random intercept
+  * Does not yet allow for between random effect correlation
+* New formula interface for phylogenetic model adapted to trait model too
+
 Version 1.4.8
 =============
 

--- a/R/TMBtrait.R
+++ b/R/TMBtrait.R
@@ -4,8 +4,8 @@
 ##########################################################################################
 trait.TMB <- function(
       y, X = NULL, xr = matrix(0), TR=NULL, formula = NULL, num.lv = 2, family = "poisson", num.lv.cor = 0, corWithinLV = FALSE,
-      Lambda.struc = "unstructured", Ab.struct = "blockdiagonal", Ab.struct.rank = NULL, Ar.struc = "diagonal", reltol = 1e-6,
-      maxit = 3000, max.iter=200, start.lvs = NULL, offset=NULL, trace=FALSE,
+      Lambda.struc = "unstructured", Ab.struct = "blockdiagonal", Ab.struct.rank = NULL, Ar.struc = "diagonal", row.eff = FALSE, reltol = 1e-6,
+      maxit = 3000, max.iter = 200, start.lvs = NULL, offset = NULL, trace = FALSE,
       link = "logit", n.init = 1, n.init.max = 10, start.params = NULL, start0 = FALSE, optimizer = "optim", dr = matrix(0), dLV = NULL, cstruc = "diag", cstruclv  = "diag", dist = list(matrix(0)), distLV = matrix(0), scalmax = 10, MaternKappa = 1.5,
       starting.val = "res", method = "VA", randomX = NULL, RElist = list(Zt = matrix(0)), Power = 1.5, diag.iter = 1, Ab.diag.iter = 0,colMat = NULL, nn.colMat = NULL, colMat.rho.struct = "single",
       Lambda.start = c(0.2, 0.5), jitter.var = 0, jitter.var.br = 0, yXT = NULL, scale.X = FALSE, randomX.start = "zero", beta0com = FALSE, rangeP = NULL, zetacutoff = NULL,
@@ -403,10 +403,9 @@ trait.TMB <- function(
       yXT <- cbind(yXT, xb)
       data <- cbind(data,xb)
     }
-    row.eff = FALSE
-    if((nrow(xr)==n)||(nrow(dr)==n))row.eff = "random"
+
     res <- start_values_gllvm_TMB(y = y, X = data[data$species==1,, drop=FALSE], TR = TR1, xr = xr, dr = dr, family = family, offset=offset, trial.size = trial.size, num.lv = num.lv, start.lvs = start.lvs, starting.val=starting.val,Power=Power,formula = formula, jitter.var=jitter.var, #!!!
-                                  yXT = yXT, row.eff = row.eff, TMB = TRUE, link=link, randomX = randomXb, beta0com = beta0com, zeta.struc = zeta.struc, disp.group = disp.group, method=method, Ntrials = Ntrials, Ab.struct = Ab.struct, Ab.struct.rank = Ab.struct.rank, colMat = colMat.old, nn.colMat = nn.colMat)
+                                  yXT = yXT, TMB = TRUE, link=link, randomX = randomXb, beta0com = beta0com, zeta.struc = zeta.struc, disp.group = disp.group, method=method, Ntrials = Ntrials, Ab.struct = Ab.struct, Ab.struct.rank = Ab.struct.rank, colMat = colMat.old, nn.colMat = nn.colMat)
     
     if(is.null(res$Power) && family == "tweedie")res$Power=1.1
     if(family=="tweedie"){

--- a/R/VP.gllvm.R
+++ b/R/VP.gllvm.R
@@ -226,20 +226,24 @@ varPartitioning.gllvm <- function(object, group = NULL, groupnames=NULL, adj.cov
       groupF <- c(groupF, LVgroups+max(groupF,0))
       
     }
-  
 
-  if ((object$row.eff %in% c("random", "fixed", "TRUE")) && is.null(r0)) {
-    if(!is.null(object$params$row.params) & !(object$row.eff %in% c("fixed", "TRUE"))){
-      rnams <- unique(names(object$params$row.params))
+  if (!isFALSE(object$row.eff) && is.null(r0)) {
+    if(!is.null(object$params$row.params.random)){
+      rnams <- unique(names(object$params$row.params.random))
       for (rn in rnams) {
-        r0 <- cbind(r0, as.matrix(object$TMBfn$env$data$dr0[,names(object$params$row.params)==rn]%*%object$params$row.params[names(object$params$row.params)==rn]) )
+        r0 <- cbind(r0, as.matrix(object$TMBfn$env$data$dr0[,names(object$params$row.params.random)==rn]%*%object$params$row.params.random[names(object$params$row.params.random)==rn]) )
         CoefMat <- rbind(CoefMat, rep(1,p))
         rownames(CoefMat)[nrow(CoefMat)] = paste("Random effect:",rn)
       }
-    } else {
-      r0 <- cbind(r0, as.matrix(object$params$row.params))
+    } 
+    if (!is.null(object$params$row.params.fixed)){
+      if(nrow(object$TMBfn$env$data$xr)!=nrow(object$y)){
+        r0 <- cbind(r0, as.matrix(object$params$row.params.fixed))
+      }else{
+        r0 <- cbind(r0, object$TMBfn$env$data$xr%*%object$params$row.params.fixed)
+      }
       CoefMat <- rbind(CoefMat, rep(1,p))
-      rownames(CoefMat)[nrow(CoefMat)] = "rowEff"
+      rownames(CoefMat)[nrow(CoefMat)] = "Fixed row effect"        
     }
     Z <- cbind(Z, r0)
   }
@@ -279,7 +283,7 @@ varPartitioning.gllvm <- function(object, group = NULL, groupnames=NULL, adj.cov
         # group = c(group,max(group) + 1:(1+(num.lv+object$num.lv.c)-1))
       }
     }
-    if((object$row.eff %in% c("random", "fixed", "TRUE"))){
+    if(!isFALSE(object$row.eff)){
       group = c(group,max(group) + 1:ncol(r0))
     }
   }

--- a/R/coef.gllvm.R
+++ b/R/coef.gllvm.R
@@ -12,16 +12,23 @@ coef.gllvm <- function(object, parm = NULL, ...)
     parm[parm%in%c("beta0","Intercept")] <- "Intercept"
   }
   
+  # backward compatibility
   
-  if (object$row.eff %in% c(TRUE, "fixed") && any(c("row.params","Row.Intercept") %in% parm)){
-    names(pars)[names(pars) == "row.params"] = "Row.Intercept"
-    parm[parm %in% c("row.params","Row.Intercept")] <- "Row.Intercept"
+  if(!inherits(object$row.eff, "formula") && object$row.eff == "random") object$params$row.params.random <- object$params$row.params
+  if(!inherits(object$row.eff, "formula") && object$row.eff == "fixed") object$params$row.params.fixed <- object$params$row.params[-1]
+  if(is.null(object$col.eff$col.eff))object$col.eff$col.eff <- FALSE
+  
+  # end backward compatibility
+  
+  if (!is.null(object$params$row.params.fixed) && any(c("row.params","Row.Intercept","Fixed.Row.effect") %in% parm)){
+    names(pars)[names(pars) == "row.params.fixed"] = "Fixed.Row.effect"
+    parm[parm %in% c("row.params.fixed","Fixed.Row.Intercept")] <- "Fixed.Row.effect"
   }
 
   
-  if (object$row.eff == "random" && any(c("row.params","Row.Intercept","Random.Row.Intercept") %in% parm)){
-    names(pars)[names(pars) == "row.params"] = "Random.Row.Intercept"
-    parm[parm %in% c("row.params","Row.Intercept","Random.Row.Intercept") ] <- "Random.Row.Intercept"
+  if (!is.null(object$params$row.params.random) && any(c("row.params","Row.Intercept","Random.Row.Intercept", "Random.Row.effect") %in% parm)){
+    names(pars)[names(pars) == "row.params.random"] = "Random.Row.effect"
+    parm[parm %in% c("row.params.random","Random.Row.Intercept") ] <- "Random.Row.effect"
   }
     
     

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -781,22 +781,22 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
           lv.X <- NULL
           lv.formula <- ~ 1
         } else if(is.null(formula)&!is.null(lv.formula)){
-          if(inherits(row.eff,"formula")){
-            if(any(colnames(X)%in%all.vars(row.eff))){
-              datayx <- data.frame(y, X[,-which(colnames(X)==all.vars(row.eff)),drop=F])
-              if(!is.null(studyDesign) && any(colnames(studyDesign)%in%all.vars(row.eff))){
-                X <-  data.frame(X,studyDesign)[,all.vars(row.eff),drop=F]
-              }else{
-                X <-  X[,all.vars(row.eff),drop=F]  
-              }
-            } else {
-              datayx <- data.frame(y, X)
-              X <- NULL
-            }
-          }else{
+          # if(inherits(row.eff,"formula")){
+          #   if(any(colnames(X)%in%all.vars(row.eff))){
+          #     datayx <- data.frame(y, X[,-which(colnames(X)==all.vars(row.eff)),drop=F])
+          #     if(!is.null(studyDesign) && any(colnames(studyDesign)%in%all.vars(row.eff))){
+          #       X <-  data.frame(X,studyDesign)[,all.vars(row.eff),drop=F]
+          #     }else{
+          #       X <-  X[,all.vars(row.eff),drop=F]  
+          #     }
+          #   } else {
+          #     datayx <- data.frame(y, X)
+          #     X <- NULL
+          #   }
+          # }else{
             datayx <- data.frame(y, X)
             X <- NULL
-          }
+          # }
           m1 <- model.frame(y ~ NULL, data = datayx)
           if(!anyBars(lv.formula)){
           labterm <- labels(terms(lv.formula))
@@ -1028,23 +1028,14 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
           studyDesign<-cbind(studyDesign, xgrps)
         }
           
-      } else if(all(grps %in% colnames(X))) {
-        if (!is.null(studyDesign)){ 
-          studyDesign=cbind(studyDesign, X)
-        } else {
-          studyDesign=X
-        }
-        xnames <- colnames(X)[!(colnames(X) %in% grps)]
-        X <- as.data.frame(X[,!(colnames(X) %in% grps)])
-        colnames(X)<-xnames
-        if(ncol(X)==0) X<-NULL
-      } else if(is.null(studyDesign)){
-        stop("Grouping variable needs to be included in 'studyDesign'")
+      } else {
+        stop("Covariates for row effects must be included in 'studyDesign'")
       }
-      } else if(!is.null(studyDesign) && any(colnames(studyDesign) %in% colnames(X))){
-        X <- X[,-which(colnames(X)%in%colnames(studyDesign)),drop=F]
-        if(ncol(X)==0)X<-NULL
       }
+      # else if(!is.null(studyDesign) && any(colnames(studyDesign) %in% colnames(X))){
+      #   X <- X[,-which(colnames(X)%in%colnames(studyDesign)),drop=F]
+      #   if(ncol(X)==0)X<-NULL
+      # }
       
       # if(is.null(bar.f)) {
       #   stop("Incorrect definition for structured random effects. Define the structure this way: 'row.eff = ~(1|group)'")

--- a/R/gllvm.R
+++ b/R/gllvm.R
@@ -181,28 +181,29 @@
 #' @return An object of class "gllvm" includes the following components:
 #'
 #'
-#'  \item{call }{ function call}
+#'  \item{call }{ function call.}
 #'  \item{y}{ (n x m) matrix of responses.}
 #'  \item{X}{ matrix or data.frame of environmental covariates.}
 #'  \item{X.design}{ design matrix of environmental covariates.}
 #'  \item{lv.X}{ design matrix or data.frame of environmental covariates for latent variables.}
 #'  \item{lv.X.design}{ design matrix or data.frame of environmental covariates for latent variables.}
-#'  \item{TR}{ Trait matrix}
-#'  \item{formula}{ Formula for predictors}
-#'  \item{lv.formula}{ Formula of latent variables in constrained and concurrent ordination}
-#'  \item{randomX }{ Formula for species specific random effects in fourth corner model}
-#'  \item{randomB }{ Boolean flag for random slopes in constrained and concurrent ordination}
-#'  \item{num.lv}{ Number of unconstrained latent variables}
-#'  \item{num.lv.c}{ Number of latent variables in concurrent ordination}
-#'  \item{num.RR}{ Number of latent variables in constrained ordination}
-#'  \item{Ntrials}{ Number of trials in a binomial model}
-#'  \item{method}{ Method used for integration}
-#'  \item{family}{ Response distribution}
-#'  \item{row.eff}{ Type of row effect used}
-#'  \item{n.init}{ Number of model runs for best fit}
-#'  \item{disp.group}{ Groups for dispersion parameters}
-#'  \item{sd }{ List of standard errors}
-#'  \item{lvs }{ Latent variables}
+#'  \item{TR}{ Trait matrix.}
+#'  \item{formula}{ Formula for predictors.}
+#'  \item{lv.formula}{ Formula of latent variables in constrained and concurrent ordination.}
+#'  \item{randomX }{ Formula for species specific random effects in fourth corner model.}
+#'  \item{Xd}{ design matrix for species specific random effects in fourth corner model.}
+#'  \item{randomB }{ Boolean flag for random slopes in constrained and concurrent ordination.}
+#'  \item{num.lv}{ Number of unconstrained latent variables.}
+#'  \item{num.lv.c}{ Number of latent variables in concurrent ordination.}
+#'  \item{num.RR}{ Number of latent variables in constrained ordination.}
+#'  \item{Ntrials}{ Number of trials in a binomial model.}
+#'  \item{method}{ Method used for integration.}
+#'  \item{family}{ Response distribution.}
+#'  \item{row.eff}{ Type of row effect used.}
+#'  \item{n.init}{ Number of model runs for best fit.}
+#'  \item{disp.group}{ Groups for dispersion parameters.}
+#'  \item{sd }{ List of standard errors.}
+#'  \item{lvs }{ Latent variables.}
 #'  \item{params}{ List of parameters
 #'  \describe{
 #'    \item{theta }{ latent variables' loadings relative to the diagonal entries of loading matrix}
@@ -214,7 +215,8 @@
 #'    \item{Br}{ column random effects}
 #'    \item{sigmaB}{ scale parameters for column-specific random effects}
 #'    \item{rho.sp}{ (positive) correlation parameter for influence strength of "colMat"}
-#'    \item{row.params }{ row-specific intercepts}
+#'    \item{row.params.random }{ row-specific random effects}
+#'    \item{row.params.fixed }{ row-specific fixed effects}
 #'    \item{sigma }{ scale parameters for row-specific random effects}
 #'    \item{phi }{ dispersion parameters \eqn{\phi} for negative binomial or Tweedie family, probability of zero inflation for ZIP family, standard deviation for gaussian family or shape parameter for gamma/beta family}
 #'    \item{inv.phi }{ dispersion parameters \eqn{1/\phi} for negative binomial}
@@ -694,7 +696,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
     col.eff <- FALSE;col.eff.formula = ~0;RElistSP <- list(Zt = matrix(0))# cs = NULL; spdr = NULL;
     # Species random effects    
     if(anyBars(formula)){
-      if(!is.null(TR))stop("For random-effects with traits, see 'randomX' argument instead.")
+      # if(!is.null(TR))stop("For random-effects with traits, see 'randomX' argument instead.")
       col.eff <- "random"
       # col.eff.formula <- reformulate(sprintf("(%s)", sapply(findbars1(formula), deparse1)))# take out fixed effects
       # keep RE part of formula unchanged
@@ -996,19 +998,24 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
     if (p == 1)
       y <- as.matrix(y)
 
-    if(!inherits(row.eff, "formula") && row.eff == "random"){
+    if(!inherits(row.eff, "formula") && !isFALSE(row.eff)){
+    if(row.eff=="random"){
       row.eff <- ~(1|site)
+    }else if(row.eff %in% c("fixed", TRUE))row.eff  <- ~site
       if(is.null(studyDesign)){
-        studyDesign <- data.frame(site = 1:n)
+        studyDesign <- data.frame(site = factor(1:n))
       }else{
-        studyDesign <- cbind(studyDesign, data.frame(site = 1:n)) 
+        studyDesign <- cbind(studyDesign, data.frame(site = factor(1:n)) )
       }
     }
     
 # Structured row parameters
-    dr = NULL; cstruc = "diag"
+    RElistRow <- list(); xr = matrix(0); dr = matrix(0); cstruc = "diag";row.eff.formula = row.eff
     if(inherits(row.eff,"formula")) {
-      bar.f <- findbars1(row.eff) # list with 3 terms
+      # first, random effects part
+      if(anyBars(row.eff)){
+      row.form <- allbars(row.eff)
+      bar.f <- findbars1(row.form) # list with 3 terms
       grps <- unique(unlist(lapply(bar.f, all.vars)))
       if(is.null(studyDesign)){
         if(!is.null(data)) {
@@ -1024,7 +1031,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
         } else {
           studyDesign=X
         }
-        xnames<-colnames(X)[!(colnames(X) %in% grps)]
+        xnames <- colnames(X)[!(colnames(X) %in% grps)]
         X <- as.data.frame(X[,!(colnames(X) %in% grps)])
         colnames(X)<-xnames
         if(ncol(X)==0) X<-NULL
@@ -1036,33 +1043,33 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
         if(ncol(X)==0)X<-NULL
       }
       
-      if(is.null(bar.f)) {
-        stop("Incorrect definition for structured random effects. Define the structure this way: 'row.eff = ~(1|group)'")
-        # } else if(!all(grps %in% colnames(X))) {
-        # stop("Grouping variable need to be included in 'X'")
-      }
+      # if(is.null(bar.f)) {
+      #   stop("Incorrect definition for structured random effects. Define the structure this way: 'row.eff = ~(1|group)'")
+      #   # } else if(!all(grps %in% colnames(X))) {
+      #   # stop("Grouping variable need to be included in 'X'")
+      # }
       # else if(!all(apply(studyDesign[,(colnames(studyDesign) %in% grps)],2,order)==c(1:n)) && (corWithin)) {
       #   stop("Data (response matrix Y and covariates X) needs to be grouped according the grouping variable: '",grps,"'")
       # } 
       # if there are nested components, the formula needs to be expanded to ensure 
       # a correct number of entries in corstruc
-      form.parts <- strsplit(deparse1(row.eff),split="\\+")[[1]]
+      form.parts <- strsplit(deparse1(row.form),split="\\+")[[1]]
       nested.parts <- grepl("/",form.parts)
       if(any(nested.parts)){
-      form.parts <- strsplit(deparse1(row.eff),split="\\+")[[1]]
+      form.parts <- strsplit(deparse1(row.form),split="\\+")[[1]]
       
       for(i in which(nested.parts))
         form.parts[i] <- paste0("(", findbars1(formula(paste0("~",form.parts[i]))),")",collapse="+")
       
       corstruc.form <- as.formula(paste0("~", paste0(form.parts,collapse="+")))
       }else{
-      corstruc.form <- row.eff
+      corstruc.form <- row.form
       }
       cstruc <- corstruc(corstruc.form)
       corWithin <- ifelse(cstruc == "diag", FALSE, corWithin)
       
       if(!is.null(bar.f)) {
-        mf <- model.frame(subbars1(row.eff),data=studyDesign)
+        mf <- model.frame(subbars1(row.form),data=studyDesign)
         # adjust correlated terms for "corWithin = TRUE"; site-specific random effects with group-specific structure
         # consequence: we can use Zt everywhere
         mf.new <- mf
@@ -1070,9 +1077,13 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
           mf.new[, corWithin] <- apply(mf[, corWithin, drop=F],2,function(x)order(order(x)))
         }
         colnames(mf.new) <- colnames(mf)
-        RElist <- mkReTrms1(bar.f,mf.new)
-        dr <- Matrix::t(RElist$Zt)
-        colnames(dr) <- rep(names(RElist$nl),RElist$nl)
+        RElistRow <- mkReTrms1(bar.f, mf.new)
+        dr <- Matrix::t(RElistRow$Zt)
+        # This line errs for formulations such as (cov|1), which includes an intercept
+        # Can be easily fixed by adding a try(..., silent = TRUE) but probably needs something more robust
+        # The bigger problem is that (cov|1) only generates a single "cstruc" entry anove, while it requires two
+        # So that the term needs to be expanded to (1|1)+(0+cov|1) first, which is not yet implemented
+        colnames(dr) <- rep(names(RElistRow$nl),RElistRow$nl)
         # add unique column names with corWithin so that we can identify them as separate random effects later
       if(any(corWithin)){
         corWithinNew <- corWithin
@@ -1086,7 +1097,39 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
         cstruc <- cstrucNew
       }
       }
-      row.eff <- "random"
+      row.eff <- nobars1_(row.eff)
+      }
+      # second, fixed effects part
+      if(inherits(row.eff, "formula") && length(all.vars(terms(row.eff)))>0){
+        # warning(still check about intercept)
+          xr <- model.matrix(row.eff, studyDesign)[,-1,drop=FALSE]
+          
+          if(nrow(dr)!=n){
+            if(!TMB)stop("Mixed effects row effects can only be fitted with 'TMB = TRUE'.")
+          }else{
+            if(!TMB)stop("Structured row effects can only be fitted with 'TMB = TRUE'.")
+          }
+          if(col.eff == "random"){
+            RElistSP$Xt <- matrix(0)
+          }
+          # if there are fixed row-effects set RE means to zero to safeguard identifiability
+          if(col.eff == "random"){
+            RElistSP$Xt <- matrix(0)
+          }  
+          }else if(inherits(row.eff, "formula") && length(all.vars(terms(row.eff)))==0){
+        # set RE means to zero if one so chooses by keeping the formula intercept-only
+        if(col.eff == "random"){
+          RElistSP$Xt <- matrix(0)
+        }
+        row.eff.formula = row.eff = FALSE
+      }
+    }
+  
+    # check if formula and row.eff contain any covariates that are the same..
+    if(length(all.vars(nobars1_(formula)))>0 && !is.null(row.eff.formula)){
+      if(any(all.vars(nobars1_(formula))%in%all.vars(nobars1_(row.eff.formula)))){
+        stop("You cannot include the same covariates in 'formula' and 'row.eff' for identifiability reasons.")
+      }
     }
     
     dLV = NULL;cstruclv = "diag"
@@ -1163,7 +1206,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
     # }
     if( any(!is.finite(y[!is.na(y)])) ) stop("Infinite values are not allowed in 'y'")
     if(any(is.na(y)))y[is.na(y)]<-NA_real_
-    if (row.eff == "random" && family == "ordinal" && TMB==FALSE) {
+    if (anyBars(row.eff.formula) && family == "ordinal" && TMB==FALSE) {
       stop("Random row effect model is not implemented for ordinal family without TMB. \n")
     }
     
@@ -1199,7 +1242,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
     if (p < 2 && !is.null(TR)) {
       stop("Fourth corner model can not be fitted with less than two response variables.\n")
     }
-    if (row.eff == "random" && !TMB) {
+    if (anyBars(row.eff.formula) && !TMB) {
       cat("Random row effect model is not implemented without TMB, so 'TMB = TRUE' is used instead. \n")
       TMB <- TRUE
     }
@@ -1266,8 +1309,9 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
 
 
     out <- list( y = y, X = X, lv.X = lv.X, lv.X.design = lv.X.design, TR = TR, data = datayx, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, num.lvcor =num.lv.cor, lv.formula = lv.formula, lvCor = lvCor, formula = formula,
-        method = method, family = family, row.eff = row.eff, col.eff = list(col.eff = col.eff, col.eff.formula = col.eff.formula, spdr = Matrix::t(RElistSP$Zt), Ab.struct = Ab.struct, Ab.struct.rank = Ab.struct.rank, colMat.rho.struct = colMat.rho.struct), corP=list(cstruc = cstruc, cstruclv = cstruclv, corWithin = corWithin, corWithinLV = corWithinLV, Astruc=0), dist=dist, distLV = distLV, randomX = randomX, n.init = n.init,
+        method = method, family = family, row.eff = row.eff.formula, col.eff = list(col.eff = col.eff, col.eff.formula = col.eff.formula, spdr = Matrix::t(RElistSP$Zt), Ab.struct = Ab.struct, Ab.struct.rank = Ab.struct.rank, colMat.rho.struct = colMat.rho.struct), corP=list(cstruc = cstruc, cstruclv = cstruclv, corWithin = corWithin, corWithinLV = corWithinLV, Astruc=0), dist=dist, distLV = distLV, randomX = randomX, n.init = n.init,
         sd = FALSE, Lambda.struc = Lambda.struc, TMB = TMB, beta0com = beta0com, optim.method=optim.method, disp.group = disp.group, NN=NN, Ntrials = Ntrials, quadratic = quadratic, randomB = randomB)
+    if(inherits(row.eff.formula, "formula"))out$row.eff <- row.eff.formula
     if(return.terms) {out$terms = term} #else {terms <- }
 
     if("la.link.bin" %in% names(pp.pars)){link = pp.pars$la.link.bin}
@@ -1313,13 +1357,11 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
         O = cbind(O,O)
       }
       
-      # trace = FALSE
-      if (row.eff == TRUE)
-        row.eff <- "fixed"
       if (!is.null(TR)) {
         fitg <- gllvm.iter(
             y = y,
             X = X,
+            xr = xr,
             # lv.X = lv.X,
             TR = TR,
             formula = formula,
@@ -1329,7 +1371,6 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             num.lv.cor=num.lv.cor,
             family = family,
             Lambda.struc = Lambda.struc,
-            row.eff = row.eff,
             reltol = reltol,
             # reltol.c = reltol.c,
             seed = seed,
@@ -1355,6 +1396,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             jitter.var = jitter.var,
             jitter.var.br = jitter.var.br,
             randomX = randomX,
+            RElist = RElistSP,
             randomX.start = randomX.start,
             beta0com = beta0com, 
             scale.X = scale.X,
@@ -1368,6 +1410,10 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             Ntrials = Ntrials,
             model = "trait.TMB"
             )
+        if(length(all.vars(col.eff.formula))>0){
+          randomX <- out$randomX <- paste0("~",paste(colnames(out$col.eff$spdr)),collapse="+")
+          out$Xrandom <- as.matrix(out$col.eff$spdr)
+        }
         out$X <- fitg$X
         out$TR <- fitg$TR
         out$formula <- fitg$formula
@@ -1376,6 +1422,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
         fitg <- gllvm.iter(
             y = y,
             X = X,
+            xr = xr,
             lv.X = lv.X.design,
             formula = formula,
             lv.formula = lv.formula,
@@ -1387,7 +1434,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
             method = method,
             Lambda.struc = Lambda.struc, Ar.struc = Ar.struc,
             sp.Ar.struc = Ab.struct, Ab.diag.iter = Ab.diag.iter, sp.Ar.struc.rank = Ab.struct.rank, 
-            row.eff = row.eff,
+            row.eff = row.eff.formula,
             col.eff = col.eff, colMat = colMat, nn.colMat = nn.colMat, colMat.rho.struct = colMat.rho.struct, randomX.start = randomX.start,
             reltol = reltol,
             reltol.c = reltol.c,
@@ -1461,7 +1508,13 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
       }else if(TMB & family == "ordinal"){
         out$zeta.struc = fitg$zeta.struc
       }
-      
+      if(!isFALSE(row.eff.formula)){
+        # need to restore the row-effect names
+        # because grouped names in dr are used to share variances in gllvm.TMB and traitTMB
+        if(!is.null(out$params$row.params.random)){ # extra security, probably redundant
+          names(out$params$row.params.random) <- row.names(RElistRow$Zt)
+        }
+      }
       #### Try to calculate sd errors
       if (!is.infinite(out$logL) && sd.errors) {
         trsd <- try({
@@ -1469,7 +1522,7 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
           out$sd <- ses$sd
           out$Hess <- ses$Hess
           out$prediction.errors <- ses$prediction.errors
-        if(!is.null(out$sd)&(num.lv.c+num.lv)>0|!is.null(out$sd)&row.eff=="random"){
+        if(!is.null(out$sd)&(num.lv.c+num.lv)>0|!is.null(out$sd)&anyBars(row.eff.formula)){
           if(!is.finite(determinant(out$Hess$cov.mat.mod)$modulus)){
             warning("Determinant of the variance-covariance matix is zero. Please double check your model for e.g. overfitting or lack of convergence. \n")
           }
@@ -1501,8 +1554,9 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
       out$start <- fitg$start
 
     } else {
-      if (row.eff == "fixed")
-        row.eff <- TRUE
+      if(anyBars(row.eff.formula))row.eff <- "random"
+      if(length(all.vars(nobars1_(row.eff.formula)))>0) row.eff = "fixed"
+      if(anyBars(row.eff.formula) && length(all.vars(nobars1_(row.eff.formula)))>0)stop("Mixed row effects only allowed with 'TMB = TRUE'.")
 
       fitg <- gllvm.VA(
           y,
@@ -1584,17 +1638,17 @@ gllvm <- function(y = NULL, X = NULL, TR = NULL, data = NULL, formula = NULL, fa
     if (is.finite(out$logL) && !is.null(TR) && NCOL(out$TR)>0 && NCOL(out$X)>0) {
       out$fourth.corner <- try(getFourthCorner(out),silent = TRUE)
     }
-    if(row.eff == "random"){
+    if(anyBars(row.eff.formula)){
       out$dr = fitg$dr
     }
     
     
-    if (is.finite(out$logL) && row.eff == "random" && FALSE){
+    if (is.finite(out$logL) && anyBars(row.eff.formula) && FALSE){
       if(method == "LA"){
-        if(abs(out$params$sigma)<0.02)
+        if(any(abs(out$params$sigma)<0.02))
           cat("Random row effects ended up to almost zero. Might be a false convergence or local maxima. You can try simpler model, less latent variables or change the optimizer. \n")
       } else{
-        if(abs(out$params$sigma)<0.02 && max(abs(out$params$sigma-sqrt(out$Ar))) < 1e-3)
+        if(any(abs(out$params$sigma)<0.02) && max(abs(out$params$sigma-sqrt(out$Ar))) < 1e-3)
           cat("Random row effects ended up to almost zero. Might be a false convergence or local maxima. You can try simpler model, less latent variables or change the optimizer. \n")
       }
     }

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -2,27 +2,30 @@
 ## GLLVM, with estimation done via Variational approximation using TMB-package
 ## Original author: Jenni Niku
 ########################################################################################
-gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisson", 
+gllvm.TMB <- function(y, X = NULL, lv.X = NULL, xr = matrix(0), formula = NULL, family = "poisson", 
                       num.lv = 2, num.lv.c = 0, num.RR = 0, num.lv.cor=0, lv.formula = NULL, corWithinLV = FALSE, randomB = FALSE, 
-                      method="VA",Lambda.struc="unstructured", Ar.struc="diagonal", sp.Ar.struc = "diagonal",  sp.Ar.struc.rank = NULL, Ab.diag.iter = 1, row.eff = FALSE, col.eff = FALSE, colMat = matrix(0), nn.colMat = NULL, colMat.rho.struct = "single", randomX.start = "res", reltol = 1e-8, reltol.c = 1e-8,
-                      maxit = 3000, max.iter=200, start.lvs = NULL, offset=NULL,
-                      trace=FALSE,link="logit",n.init=1,n.init.max = 10, restrict=30,start.params=NULL, RElist = NULL, dr=NULL, dLV=NULL, cstruc = "diag", cstruclv = "diag", dist =list(matrix(0)), distLV = matrix(0),
-                      optimizer="optim",starting.val="res",Power=1.5,diag.iter=1, dependent.row = FALSE, scalmax = 10, MaternKappa = 1.5, rangeP = NULL,
-                      Lambda.start=c(0.1,0.5), quad.start=0.01, jitter.var=0, jitter.var.br = 0, zeta.struc = "species", quadratic = FALSE, start.struc = "LV", optim.method = "BFGS", disp.group = NULL, NN=matrix(0), setMap=NULL, Ntrials = 1, beta0com = FALSE, csBlv = matrix(0)) { 
+                      method = "VA",Lambda.struc = "unstructured", Ar.struc="diagonal", sp.Ar.struc = "diagonal",  sp.Ar.struc.rank = NULL, Ab.diag.iter = 1, row.eff = FALSE, col.eff = FALSE, colMat = matrix(0), nn.colMat = NULL, colMat.rho.struct = "single", randomX.start = "res", reltol = 1e-8, reltol.c = 1e-8,
+                      maxit = 3000, max.iter = 200, start.lvs = NULL, offset = NULL,
+                      trace = FALSE, link = "logit", n.init = 1, n.init.max = 10, restrict = 30, start.params = NULL, RElist = NULL, dr = matrix(0), dLV=NULL, cstruc = "diag", cstruclv = "diag", dist = list(matrix(0)), distLV = matrix(0),
+                      optimizer = "optim", starting.val = "res", Power = 1.5, diag.iter = 1, dependent.row = FALSE, scalmax = 10, MaternKappa = 1.5, rangeP = NULL,
+                      Lambda.start = c(0.1,0.5), quad.start = 0.01, jitter.var = 0, jitter.var.br = 0, zeta.struc = "species", quadratic = FALSE, start.struc = "LV", optim.method = "BFGS", disp.group = NULL, NN = matrix(0), setMap = NULL, Ntrials = 1, beta0com = FALSE, csBlv = matrix(0)) { 
+
   # , Dthreshold=0
   # If there is no random effects/LVs set diag iter to zero:
   # if(!is.null(dr) && ncol(dr) != length(Ar.struc) && length(Ar.struc==1)){
   #   Ar.struc <- rep(Ar.struc, ncol(dr))
   # }else if(length(Ar.struc) != length(Ar.struc))stop("'Ar.struc' should be of the same length as the number of row effects.")
-  if(((num.lv+num.lv.c)==0) & (row.eff!="random" || Ar.struc == "diagonal") & (randomB==FALSE)) diag.iter <-  0
+  n <- nr <- nu <- dim(y)[1]
+  p <- dim(y)[2]
+  
+  if(((num.lv+num.lv.c)==0) & ((nrow(dr)!=n) || Ar.struc == "diagonal") & (randomB==FALSE)) diag.iter <-  0
   if(col.eff != "random" || sp.Ar.struc%in%c("diagonal","MNdiagonal","diagonalCL1")) Ab.diag.iter <- 0
   
   if(is.null(colMat) && !(sp.Ar.struc %in% c("diagonal","blockdiagonal")))sp.Ar.struc <- "blockdiagonal"
   
   if(!is.null(start.params)) starting.val <- "zero"
   ignore.u <- FALSE
-  n <- nr <- nu <- dim(y)[1]
-  p <- dim(y)[2]
+  
   times <- 1
   if(is.null(disp.group)) disp.group <- 1:NCOL(y)
   if(family=="binomial" && length(Ntrials) != 1 && length(Ntrials) != p){
@@ -39,7 +42,6 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   
   # Structure for row effects
   model = 0
-  xr = NULL
   # if(rstruc==0){ # No structure
   #   dr <- diag(n)
   # }
@@ -146,7 +148,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   Astruc = 0;
   scaledc = 0;
   rho.lv =NULL  
-  if(!is.null(dr)){
+  if(nrow(dr)==n){
     nr <- table(factor(colnames(dr),levels=unique(colnames(dr))))
     # distance matrix checks
     if(any(cstruc%in%c("corExp","corMatern"))){
@@ -253,8 +255,8 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   if (is.null(colnames(y)))
     colnames(y) <- paste("Col", 1:p, sep = "")
   if(family == "ordinal") {
-    y00<-y
-    if(min(y)==0){ y=y+1}
+    y00 <- y
+    if(min(y) == 0){ y = y+1}
   }
   
   # Define design matrix for covariates
@@ -300,11 +302,12 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
   
   ## Set initial values for model parameters (including dispersion prm) and latent variables
   
-  out <- list( y = y, X = X, logL = Inf, num.lv = num.lv, num.lv.c = num.lv.c, row.eff = row.eff, col.eff = col.eff, colMat = colMat, family = family, X.design = X, method = method, zeta.struc = zeta.struc, Ntrials = Ntrials)
+  out <- list( y = y, X = X, logL = Inf, num.lv = num.lv, num.lv.c = num.lv.c, col.eff = col.eff, colMat = colMat, family = family, X.design = X, method = method, zeta.struc = zeta.struc, Ntrials = Ntrials)
   
     #### Calculate starting values
     if((num.lv.c+num.lv+num.RR)==0 && !is.null(RElist) || randomX.start=="zero") RElist <- NULL # calculating starting values for REs and LVs
-    fit <- start_values_gllvm_TMB(y = y, X = Xorig, formula = formula, lv.X = lv.X, TR = NULL, family = family, offset= offset, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, start.lvs = start.lvs, starting.val = starting.val, Power = Power, jitter.var = jitter.var, row.eff = row.eff, TMB=TRUE, link=link, zeta.struc = zeta.struc, disp.group = disp.group, method=method, randomB = randomB, Ntrials = Ntrials, Ab.struct = sp.Ar.struc, Ab.struct.rank = sp.Ar.struc.rank, colMat = colMat.old, nn.colMat = nn.colMat, RElist = RElist, beta0com = beta0com)
+    if((nrow(xr)==n)||(nrow(dr)==n))row.eff = "random"
+    fit <- start_values_gllvm_TMB(y = y, xr = xr, dr = dr, X = Xorig, formula = formula, lv.X = lv.X, TR = NULL, family = family, offset= offset, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, start.lvs = start.lvs, starting.val = starting.val, Power = Power, jitter.var = jitter.var, row.eff = row.eff, TMB=TRUE, link=link, zeta.struc = zeta.struc, disp.group = disp.group, method=method, randomB = randomB, Ntrials = Ntrials, Ab.struct = sp.Ar.struc, Ab.struct.rank = sp.Ar.struc.rank, colMat = colMat.old, nn.colMat = nn.colMat, RElist = RElist, beta0com = beta0com)
     
     if(is.null(fit$Power) && family == "tweedie")fit$Power=1.1
     if(family=="tweedie"){
@@ -372,8 +375,10 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       if(col.eff == "random"){
         if(!is.null(RElist) && starting.val == "res" && randomX.start=="res" && (num.lv.c+num.RR+num.lv)>0){ # getting some improved starting values
+          if(nrow(Xt)==n){
           B <- rep(0, ncol(spdr))
           B[colnames(spdr)%in%colnames(Xt)] <- fit$fitstart$B
+          }
           sigmaB <- log(sqrt(diag(fit$fitstart$sigmaB)))
           if(ncol(cs)==2){
             sigmaB <- c(sigmaB, fit$fitstart$TMBfnpar[names(fit$fitstart$TMBfnpar) == "sigmaB"][(ncol(spdr)+1):(ncol(spdr)+nrow(cs))])
@@ -395,22 +400,37 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         
       fit$Br <- Br
-      fit$B <- B
+      if(nrow(Xt)==n)fit$B <- B
       # colMat signal strength
       if(any(colMat[row(colMat)!=col(colMat)]!=0))sigmaB <- c(sigmaB, rep(log(-log(0.5)),ifelse(colMat.rho.struct == "single", 1, ncol(spdr))))
       fit$sigmaB <- sigmaB
-      }else{
-        sigmaB <- 0;Br <- matrix(0);B<-matrix(0)
       }
-      row.params <- NULL
+      if(col.eff != "random"){
+        sigmaB <- 0;Br <- matrix(0);B<-matrix(0)
+      }else if(nrow(Xt)!=n && col.eff == "random"){
+        B <- matrix(0)
+      }
+      row.params <- row.params.fixed <- row.params.random <- NULL
       
-      if (row.eff != FALSE) {
-        row.params <- fit$row.params
-        if (row.eff == "random") {
-          try(row.params <- (Matrix::t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)
-          sigma <- aggregate(as.matrix(row.params), by = list(row.names(row.params)), FUN = sd)[,2]
-        }
-      }#rep(0,n)
+      # if ((nrow(xr)==n) || (nrow(dr)==n)) {
+      #   row.params <- fit$row.params
+      #   if(nrow(xr)==n){
+      #     row.lm <- lm(row.params~0+xr)
+      #     row.params.fixed <- coef(row.lm)
+      #     row.params <- residuals(row.lm)
+      #   }
+      #   if (nrow(dr)==n) {
+      #     row.params<<-row.params
+      #     try(row.params.random <- (Matrix::t(dr)%*%(row.params))/(dim(dr)[1]/dim(dr)[2]), silent = TRUE)
+      #     sigma <- aggregate(as.matrix(row.params), by = list(row.names(row.params)), FUN = sd)[,2]
+      #   }
+      # }
+      if ((nrow(xr)==n) || (nrow(dr)==n)) {
+        row.params.random <- fit$row.params.random
+        row.params.fixed <- fit$row.params.fixed
+        sigma <- fit$sigma
+      }
+      
       lvs <- NULL
       if ((num.lv+num.lv.c) > 0)
         lvs <- matrix(fit$index, ncol = num.lv+num.lv.c)
@@ -418,7 +438,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     } else{
       if (all(dim(start.params$y) == dim(y)) &&
           is.null(X) == is.null(start.params$X) &&
-          (row.eff == start.params$row.eff) && (col.eff == start.params$col.eff$col.eff)) {
+          (isTRUE(all.equal(row.eff, start.params$row.eff)) && (col.eff == start.params$col.eff$col.eff))) {
         if(class(start.params)[2]=="gllvm.quadratic" && quadratic != FALSE){
           lambda2 <- start.params$params$theta[,-c(1:(start.params$num.lv+start.params$num.lv.c+start.params$num.RR)),drop=F]
         }else if(class(start.params)[1]=="gllvm" && quadratic != FALSE){
@@ -456,12 +476,11 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           
         }
         
-        row.params <- NULL
-        if (start.params$row.eff != FALSE) {
-          row.params <- start.params$params$row.params
-          if(row.eff=="fixed")
-            row.params[1] <- 0
-          if(row.eff=="random")
+        row.params.random <- row.params.fixed <- NULL
+        if (!isFALSE(start.params$row.eff)) {
+          row.params.fixed <- start.params$params$row.params.fixed
+          row.params.random <- start.params$params$row.params.random
+          if(nrow(dr)==n)
             sigma <- start.params$params$sigma
         }## row parameters
         lvs <- NULL
@@ -566,7 +585,12 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       offset <- matrix(0, nrow = n, ncol = p)
     
     current.loglik <- -1e6; iter <- 1; err <- 10;
-    if(!is.null(row.params)){ r0 <- row.params} else {r0 <- rep(0,n)}
+    if(!is.null(row.params.fixed)){ r0f <- row.params.fixed} else {r0f <- rep(0,ncol(xr))}
+    if(nrow(dr)!=n)r0r <- 0
+    if(nrow(xr)!=n)r0f <- 0
+    if(!is.null(row.params.random)){
+      r0r <- row.params.random
+    }
     if(beta0com) a <- rep(mean(beta0), p)
     if(!beta0com) a <- c(beta0)
     lambda=0
@@ -612,10 +636,15 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     if(is.list(setMap)) {
       map.list <- setMap
     }
-    map.list$B <- map.list$sigmaij <- factor(NA)
+    map.list$sigmaij <- factor(NA)
 
     xb<-matrix(0);sigmaij=0; lg_Ar=0; Abb=0; Ab_lv = 0;
-    if(row.eff==FALSE) map.list$r0 <- factor(rep(NA,n))
+    if(nrow(xr)!=n){
+      map.list$r0f <- factor(NA)
+    }
+    if(nrow(dr)!=n){
+      map.list$r0r <- factor(NA)
+    }
     if(col.eff==FALSE) {map.list$Br <- factor(NA);map.list$sigmaB <- factor(NA); map.list$Abb <- factor(NA);map.list$B <- factor(NA)}
     if(randomB==FALSE){
       map.list$sigmab_lv <- factor(NA)
@@ -657,11 +686,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     if((num.lv+num.lv.c)==0)map.list$sigmaLV = factor(NA)
     
     randoml=c(0,0,0, 0)
-    if(row.eff=="fixed"){xr <- matrix(1,1,p)} else {xr <- matrix(0,1,p)}
-    if(row.eff=="random") randoml[1]=1
+    if(nrow(dr)==n) randoml[1]=1
     if(col.eff == "random") randoml[4]  <- 1
     nlvr=num.lv+num.lv.c
-    if(row.eff=="fixed"){xr <- matrix(1,1,p)} else {xr <- matrix(0,1,p)}
     if(randomB!=FALSE){
       randoml[3]<-1
     }
@@ -673,7 +700,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     if(!is.null(X)){Xd <- cbind(1,X)} else {Xd <- matrix(1,n)}
   
     # map species common effects for REs
-    if(col.eff == "random"){
+    if(col.eff == "random" && nrow(Xt)==n){
       map.list$B <- 1:ncol(spdr)
       if(any(!colnames(Xt)%in%colnames(spdr))){
         stop("There was a problem with the model. Did you use ordered constrasts in the random effect perhaps?")
@@ -699,9 +726,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     b <- NULL; if(!is.null(X)) b <- matrix(betas, ncol(X), p,byrow = TRUE)
     extra <- c(0,0,0)
     
-    optr<-NULL
-    timeo<-NULL
-    se <- NULL
+    optr <- timeo <- NULL
     
     ## Set up starting values for scale (and shape) parameters for correlated LVs
     if(num.lv.cor>0 & cstruclvn>0){
@@ -750,7 +775,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
     
     ### VA method, used only if there is some random effects/LVs in the model
     
-    if(((method %in% c("VA", "EVA")) && (nlvr>0 || row.eff == "random" || !isFALSE(randomB) || col.eff == "random")) ){
+    if(((method %in% c("VA", "EVA")) && (nlvr>0 || (nrow(dr)==n) || !isFALSE(randomB) || col.eff == "random")) ){
       
       # Variational covariances for latent variables
       if((num.lv+num.lv.c)>0){
@@ -953,7 +978,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       }
           } else {spAr <- 0}
       # Variational covariances for  random rows
-      if(row.eff == "random"){
+      if(nrow(dr)==n){
         lg_Ar <- rep(log(Lambda.start[2]), sum(nr))
         
         if(Ar.struc!="diagonal" && diag.iter == 0){
@@ -963,13 +988,13 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
 
       #quadratic model starting values
       if(quadratic == TRUE && start.struc == "LV"){
-        start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, row.eff=row.eff, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = starting.val, Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
+        start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = starting.val, Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
         if(inherits(start.fit,"try-error")&starting.val!="zero"){
-          start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, row.eff=row.eff, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = "zero", Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
+          start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = "zero", Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
         }
         if(!inherits(start.fit,"try-error")&starting.val!="zero"){
           if(is.null(start.fit$lvs)){
-            start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, row.eff=row.eff, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = "zero", Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
+            start.fit <- try(gllvm.TMB(y=y, X=X, lv.X = lv.X, num.lv=num.lv, num.lv.c = num.lv.c, num.RR = num.RR, family = family, Lambda.struc = Lambda.struc, reltol=reltol, maxit = maxit, start.lvs = start.lvs, offset = offset, n.init = 1, diag.iter=diag.iter, dependent.row=dependent.row, quadratic="LV", starting.val = "zero", Lambda.start = Lambda.start, quad.start = quad.start, jitter.var = jitter.var, zeta.struc = zeta.struc, optimizer = optimizer, optim.method = optim.method, max.iter=max.iter, start.struc="all", disp.group = disp.group, randomB = randomB, Ntrials = Ntrials),silent=T)
           }
         }
         if(!inherits(start.fit,"try-error")){
@@ -1005,7 +1030,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       if(num.RR==0 && num.lv.c==0) map.list$b_lv = factor(NA)
       
       ## Row effect settings
-      if(row.eff=="random"){
+      if(nrow(dr)==n){
         # if(dependent.row&quadratic==F|dependent.row&starting.val=="zero") 
         sigmanew <- map.list$log_sigma <- NULL
         iter = 1 # keep track of # spatial structures
@@ -1033,7 +1058,6 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         sigma=0
         map.list$log_sigma <- factor(NA)
         map.list$lg_Ar <- factor(NA)
-        # if(row.eff != "fixed") map.list$r0 <- factor(rep(NA, length(r0)))
       }
       
       if(quadratic == FALSE){
@@ -1070,7 +1094,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       ## generate starting values quadratic coefficients in some cases
       if(starting.val!="zero" && quadratic != FALSE && (num.lv+num.lv.c+num.RR)>0){
-        data.list = list(y = y, x = Xd, x_lv = lv.X, xr=xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = 1, family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
+        data.list = list(y = y, x = Xd, x_lv = lv.X, xr = xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = 1, family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
         
         # if(row.eff=="random"){
         #   if(dependent.row) sigma<-c(log(sigma), rep(0, num.lv))
@@ -1082,7 +1106,8 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         # }
         map.list2 <- map.list 
         map.list2$sigmaLV = factor(rep(NA,length(sigma.lv)))
-        map.list2$r0 = factor(rep(NA, length(r0)))
+        map.list2$r0r = factor(rep(NA, length(r0r)))
+        map.list2$r0f = factor(rep(NA, length(r0f)))
         map.list2$b_lv = factor(rep(NA, length(b.lv)))
         map.list2$Ab_lv = factor(rep(NA, length(Ab_lv)))
         map.list2$sigmab_lv = factor(rep(NA, length(sigmab_lv)))
@@ -1098,10 +1123,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         map.list2$sigmaij = factor(rep(NA,length(sigmaij)))
         map.list2$Au = factor(rep(NA, length(Au)))
         map.list2$zeta = factor(rep(NA, length(zeta)))
-        map.list2$r0 = factor(rep(NA, length(r0)))
         map.list2$lg_Ar = factor(rep(NA, length(lg_Ar)))
         
-        parameter.list = list(r0 = matrix(r0), b = rbind(a,b), b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma, sigmaB = sigmaB, rho_lvc=rho_lvc, Au=Au, lg_Ar =lg_Ar, Abb = spAr, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, thetaH = thetaH, bH=bH
+        parameter.list = list(r0r = matrix(r0r), r0f = matrix(r0f), b = rbind(a,b), b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma, sigmaB = sigmaB, rho_lvc=rho_lvc, Au=Au, lg_Ar =lg_Ar, Abb = spAr, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, thetaH = thetaH, bH=bH
         
         objr <- TMB::MakeADFun(
           data = data.list, silent=TRUE,
@@ -1135,9 +1159,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       ### Set up data and parameters
       
-      data.list <- list(y = y, x = Xd, x_lv = lv.X , xr=xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs =  cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
+      data.list <- list(y = y, x = Xd, x_lv = lv.X , xr = xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs =  cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
 
-      parameter.list <- list(r0 = matrix(r0), b = rbind(a,b), sigmaB = sigmaB, Abb = spAr, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma, rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
+      parameter.list <- list(r0r = matrix(r0r), r0f = matrix(r0f), b = rbind(a,b), sigmaB = sigmaB, Abb = spAr, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma, rho_lvc=rho_lvc, Au=Au, lg_Ar=lg_Ar, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
 
       #### Call makeADFun
       objr <- TMB::MakeADFun(
@@ -1194,12 +1218,22 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       
       ### Now diag.iter, improves the model fit sometimes
-      if((diag.iter>0) && (!(Lambda.struc %in% c("diagonal", "diagU")) && (((nlvr+randoml[3]*num.RR)>1) | (num.lv.cor>0)) && !inherits(optr,"try-error") | (row.eff=="random" & Ar.struc=="unstructured")) | ((Ab.diag.iter>0) && (col.eff=="random" && sp.Ar.struc%in%c("blockdiagonal","MNunstructured","unstructured","diagonalCL2","CL1","CL2")))){
+      if((diag.iter>0) && (!(Lambda.struc %in% c("diagonal", "diagU")) && (((nlvr+randoml[3]*num.RR)>1) | (num.lv.cor>0)) && !inherits(optr,"try-error") | ((nrow(dr)==n) & Ar.struc=="unstructured")) | ((Ab.diag.iter>0) && (col.eff=="random" && sp.Ar.struc%in%c("blockdiagonal","MNunstructured","unstructured","diagonalCL2","CL1","CL2")))){
         objr1 <- objr
         optr1 <- optr
         param1 <- optr$par
         nam <- names(param1)
-        if(length(param1[nam=="r0"])>0){ r1 <- matrix(param1[nam=="r0"])} else {r1 <- matrix(r0)}
+        if(length(param1[nam=="r0r"])>0){ r0r1 <- matrix(param1[nam=="r0r"])} else {r0r1 <- matrix(0)}
+        if(length(param1[nam=="r0f"])>0){ r0f1 <- matrix(param1[nam=="r0f"])} else {r0f1 <- matrix(0)}
+        if(nrow(dr)==n){
+          log_sigma1 <- ifelse(param1[nam=="log_sigma"]==0,1e-3,param1[nam=="log_sigma"])
+          if(!is.null(map.list$log_sigma)) log_sigma1 = log_sigma1[map.list$log_sigma]
+          lg_Ar<- log(exp(param1[nam=="lg_Ar"][1:sum(nr)])+1e-3)
+          if(Ar.struc=="unstructured"){
+            lg_Ar <- c(lg_Ar, rep(1e-3, sum(nr*(nr-1)/2)))
+          }
+        } else {log_sigma1 = 0}
+        
         b1 <- matrix(param1[nam=="b"],num.X+1,p)
         if(!isFALSE(randomB)){
           if(randomB!="iid"){
@@ -1213,8 +1247,12 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           Ab_lv1 <- 0
         }
         if(col.eff == 'random'){
+          if(nrow(Xt)==n){
           B1 <- matrix(0, ncol = 1, nrow = ncol (spdr))
           B1[!is.na(map.list$B)] <- param1[names(param1)=="B"]
+          }else{
+            B1 <- matrix(0)
+          }
           Br1 <- matrix(param1[nam=="Br"],nrow=ncol(spdr))
           sigmaB1 <- ifelse(round(param1[nam=="sigmaB"],8)==0,1e-3,param1[nam=="sigmaB"])
           # if(!is.null(colMat))param1[nam=="sigmaB"][length(param1[nam=="sigmaB"])] <- ifelse(tail(param1[nam=="sigmaB"], ifelse(colMat.rho.struct == "single",1,ncol(spdr)))>0.5,0.5,tail(param1[nam=="sigmaB"], ifelse(colMat.rho.struct == "single",1,ncol(spdr))))
@@ -1259,15 +1297,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         if(family=="ZINB"){lg_phiZINB1 <- param1[nam=="lg_phiZINB"][map.list$lg_phiZINB]}else{lg_phiZINB1<-log(ZINBphi)}
         if(family=="tweedie" && is.null(Power)) ePower = param1[nam == "ePower"]
         sigmaij1 <- param1[nam=="sigmaij"]
-        if(row.eff == "random"){
-          log_sigma1 <- ifelse(param1[nam=="log_sigma"]==0,1e-3,param1[nam=="log_sigma"])
-          if(!is.null(map.list$log_sigma)) log_sigma1 = log_sigma1[map.list$log_sigma]
-          lg_Ar<- log(exp(param1[nam=="lg_Ar"][1:sum(nr)])+1e-3)
-          if(Ar.struc=="unstructured"){
-            lg_Ar <- c(lg_Ar, rep(1e-3, sum(nr*(nr-1)/2)))
-          }
-        } else {log_sigma1 = 0}
-        
+
         if(num.lv.cor>0){
           Au1<- c(param1[nam=="Au"])
           if(corWithinLV) {
@@ -1321,9 +1351,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         
         #Because then there is no next iteration
-        data.list = list(y = y, x = Xd,  x_lv = lv.X, xr=xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
+        data.list = list(y = y, x = Xd,  x_lv = lv.X, xr = xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = Abstruc, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
         
-        parameter.list <- list(r0=r1, b = b1, b_lv = b.lv1, sigmaB = sigmaB1, Abb = spAr1, sigmab_lv = sigmab_lv1, Ab_lv = Ab_lv1, B = B1, Br=Br1,lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1,lg_phi=lg_phi1,sigmaij=sigmaij,log_sigma=log_sigma1, rho_lvc=rho_lvc, Au=Au1, lg_Ar=lg_Ar, zeta=zeta, ePower = ePower, lg_phiZINB = lg_phiZINB1) #, scaledc=scaledc,thetaH = thetaH, bH=bH
+        parameter.list <- list(r0r = r0r1, r0f = r0f1, b = b1, b_lv = b.lv1, sigmaB = sigmaB1, Abb = spAr1, sigmab_lv = sigmab_lv1, Ab_lv = Ab_lv1, B = B1, Br=Br1,lambda = lambda1, lambda2 = t(lambda2), sigmaLV = sigma.lv1, u = u1,lg_phi=lg_phi1,sigmaij=sigmaij,log_sigma=log_sigma1, rho_lvc=rho_lvc, Au=Au1, lg_Ar=lg_Ar, zeta=zeta, ePower = ePower, lg_phiZINB = lg_phiZINB1) #, scaledc=scaledc,thetaH = thetaH, bH=bH
         
         objr <- TMB::MakeADFun(
           data = data.list, silent=TRUE,
@@ -1512,10 +1542,11 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         #diag(theta) <- exp(diag(theta)) # !!!
       }
       
-      if(row.eff!=FALSE) {
-        ri = names(param)=="r0"
-        row.params = param[ri]#c(0,param[ri])
-        if(row.eff=="random"){
+      if((nrow(dr) ==n) || (nrow(xr) == n)) {
+        rir = names(param)=="r0r"
+        rif = names(param)=="r0f"
+        if(nrow(dr)==n){
+          row.params.random <- param[rir]
           sigma = param[names(param)=="log_sigma"]
           # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) rho = param[names(param)=="log_sigma"][2] / sqrt(1.0 + param[names(param)=="log_sigma"][2]^2);
           # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {
@@ -1523,6 +1554,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           #   # scaledc<- exp(param[names(param)=="scaledc"]);
           # }
           # if(num.lv>0 && dependent.row && rstruc==0) sigma = c(sigma,(param[names(param)=="log_sigma"])[-1])
+        }
+        if(nrow(xr)==n){
+          row.params.fixed <- param[rif]
         }
       }
       
@@ -1536,7 +1570,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         Bri = names(param)=="Br"
         Br = matrix(param[Bri], nrow = ncol(spdr))#c(0,param[ri])
-        B = param[names(param)=="B"]
+        if(nrow(Xt)==n)B = param[names(param)=="B"]
       }
       
       betaM <- matrix(param[bi],p,num.X+1,byrow=TRUE)
@@ -1551,7 +1585,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       if(!isFALSE(randomB)&(num.lv.c+num.RR)>0&randomB!="iid")sigmab_lv <- param[sib]
       new.loglik <- objr$env$value.best[1]
       
-    } else if(method=="LA" || (nlvr==0 && (method %in% c("VA", "EVA")) && row.eff!="random" && isFALSE(randomB) && isFALSE(col.eff))){
+    } else if(method=="LA" || (nlvr==0 && (method %in% c("VA", "EVA")) && (nrow(dr)!=n) && isFALSE(randomB) && isFALSE(col.eff))){
       ## Laplace method / nlvr==0
       if(!is.null(X)){Xd=cbind(1,X)} else {Xd=matrix(1,n)}
       ### Family settings
@@ -1599,7 +1633,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       
       ## generate starting values quadratic coefficients in some cases
       if(starting.val!="zero" && quadratic == TRUE && num.RR>0&(num.lv+num.lv.c)==0 && start.struc=="LV"){
-        data.list = list(y = y, x = Xd, x_lv = lv.X, xr=xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = 0, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = 1, family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
+        data.list = list(y = y, x = Xd, x_lv = lv.X, xr = xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = 0, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = 1, family=familyn,extra=extra,method=switch(method, VA=0, EVA=2),model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
         
         map.list2 <- map.list 
         map.list2$log_sigma = factor(NA)
@@ -1607,7 +1641,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         map.list2$b_lv <- factor(rep(NA,length(b.lv)))
         map.list2$B <- factor(rep(NA, length(B)))
         
-        parameter.list = list(r0 = matrix(r0), b = rbind(a,b), sigmaB = sigmaB, Abb = spAr, b_lv = b.lv, sigmab_lv = 0, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma,rho_lvc=rho_lvc, Au=0, lg_Ar =0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, thetaH = thetaH, bH=bH
+        parameter.list = list(r0r = matrix(r0r), r0f = matrix(r0f), b = rbind(a,b), sigmaB = sigmaB, Abb = spAr, b_lv = b.lv, sigmab_lv = 0, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u,lg_phi=log(phi),sigmaij=sigmaij,log_sigma=sigma,rho_lvc=rho_lvc, Au=0, lg_Ar =0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc, thetaH = thetaH, bH=bH
         
         objr <- TMB::MakeADFun(
           data = data.list, silent=TRUE,
@@ -1633,7 +1667,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           # fit$b.lv <- b.lv
         }
       }
-      data.list = list(y = y, x = Xd, x_lv = lv.X, xr=xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = 0, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=1,model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
+      data.list = list(y = y, x = Xd, x_lv = lv.X, xr = xr, dr0 = dr, dLV = dLV, colMatBlocksI = blocks, Abranks = Abranks, Abstruc = 0, xb = spdr, cs = cs, offset=offset, nr = nr, num_lv = num.lv, num_lv_c = num.lv.c, num_RR = num.RR, num_corlv=num.lv.cor, quadratic = ifelse(quadratic!=FALSE,1,0), family=familyn,extra=extra,method=1,model=0,random=randoml, zetastruc = ifelse(zeta.struc=="species",1,0), times = times, cstruc=cstrucn, cstruclv = cstruclvn, dc=dist, dc_lv = distLV, Astruc=Astruc, NN = NN, Ntrials = Ntrials, nncolMat = nncolMat, csb_lv = csBlv)
       
       if(family %in% c("ordinal", "orderedBeta")){
         data.list$method = 0
@@ -1662,9 +1696,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
       }
       
       # Row parameter settings
-      if(row.eff=="random"){
+      if(nrow(dr)==n){
         randoml[1] <- 1
-        randomp <- c(randomp,"r0")
+        randomp <- c(randomp,"r0r")
         
         sigmanew <- map.list$log_sigma <- NULL
         iter <- 1
@@ -1714,7 +1748,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         data.list$method = 0
       }
       
-      parameter.list = list(r0=matrix(r0), b = rbind(a,b), sigmaB = sigmaB, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi),sigmaij=sigmaij,log_sigma=c(sigma), rho_lvc=rho_lvc, Au=0, lg_Ar=0, Abb=0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
+      parameter.list = list(r0r= matrix(r0r), r0f = matrix(r0f), b = rbind(a,b), sigmaB = sigmaB, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi),sigmaij=sigmaij,log_sigma=c(sigma), rho_lvc=rho_lvc, Au=0, lg_Ar=0, Abb=0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
       
       #### Call makeADFun
       objr <- TMB::MakeADFun(
@@ -1798,7 +1832,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
 
         if(!(family %in% c("poisson","binomial","ordinal","exponential"))) phi <- exp(objr$env$last.par.best[names(objr$env$last.par.best)=="lg_phi"])[disp.group]
         if(!(family %in% c("ZINB"))) ZINBphi <- exp(objr$env$last.par.best[names(objr$env$last.par.best)=="lg_phiZINB"])[map.list$lg_phiZINB]
-        parameter.list = list(r0=matrix(r0), b = b, sigmaB = sigmaB, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi),sigmaij=sigmaij,log_sigma=c(sigma), rho_lvc=rho_lvc, Au=0, lg_Ar=0, Abb=0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
+        parameter.list = list(r0r = matrix(r0r), r0f = matrix(r0f), b = b, sigmaB = sigmaB, b_lv = b.lv, sigmab_lv = sigmab_lv, Ab_lv = Ab_lv, B = B, Br=Br,lambda = lambda, lambda2 = t(lambda2), sigmaLV = (sigma.lv), u = u, lg_phi=log(phi),sigmaij=sigmaij,log_sigma=c(sigma), rho_lvc=rho_lvc, Au=0, lg_Ar=0, Abb=0, zeta=zeta, ePower = ePower, lg_phiZINB = log(ZINBphi)) #, scaledc=scaledc,thetaH = thetaH, bH=bH
         
         #### Call makeADFun
         objr <- TMB::MakeADFun(
@@ -1947,17 +1981,15 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         
       }
       
-      if(row.eff!=FALSE) {
-        ri <- names(param)=="r0"
-        row.params=param[ri]
-        if(row.eff=="random"){
-          sigma<-param[names(param)=="log_sigma"]
-          # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,3))) rho<- param[names(param)=="log_sigma"][2] / sqrt(1.0 + param[names(param)=="log_sigma"][2]^2);
-          # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(2,4))) {
-          #   rho<- exp(param[names(param)=="log_sigma"][-1]);
-          #   # scaledc<- exp(param[names(param)=="scaledc"]);
-          # }
-          # if((num.lv+num.lv.c)>0 && dependent.row && rstruc==0) sigma <- c(sigma, (param[names(param)=="log_sigma"])[-1])
+      if((nrow(dr)==n) || (nrow(xr)==n)) {
+        rir = names(param)=="r0r"
+        rif = names(param)=="r0f"
+        if(nrow(dr)==n){
+          row.params.random <- param[rir]
+          sigma = param[names(param)=="log_sigma"]
+        }
+        if(nrow(xr)==n){
+          row.params.fixed <- param[rif]
         }
       }
       if(col.eff=="random"){
@@ -1970,7 +2002,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         Bri = names(param)=="Br"
         Br = matrix(param[Bri], nrow = ncol(spdr))#c(0,param[ri])
-        B <- param[names(param)=="B"]
+        if(nrow(Xt)==n)B <- param[names(param)=="B"]
       }
       betaM <- matrix(param[bi],p,num.X+1,byrow=TRUE)
 
@@ -2176,8 +2208,8 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         
       }
-      if(row.eff!=FALSE) {
-        if(row.eff=="random"){ 
+      if((nrow(dr)==n) || (nrow(xr == n))) {
+        if(nrow(dr)==n){ 
           out$dr=dr
           iter = 1 # keep track of index
           for(re in 1:length(cstrucn)){
@@ -2207,7 +2239,8 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
             }
           }
           out$params$sigma=sigma; 
-          
+          out$params$row.params.random <- row.params.random; 
+          try(names(out$params$row.params.random) <- colnames(dr), silent = TRUE)
           # if((rstruc ==2 | (rstruc == 1)) & (cstrucn %in% c(1,2,3,4))){ 
           #   out$params$rho <- rho
           #   names(out$params$rho)="rho"
@@ -2215,15 +2248,20 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           # }
           # if((num.lv+num.lv.c)>1 && dependent.row) names(out$params$sigma) <- paste("sigma",c("",1:(num.lv+num.lv.c)), sep = "")
         }
-        out$params$row.params <- row.params; 
-        try(names(out$params$row.params) <- colnames(dr), silent = TRUE)
+        if(nrow(xr)==n){
+          out$params$row.params.fixed <- row.params.fixed
+          try(names(out$params$row.params.fixed) <- colnames(xr), silent = TRUE)
+        }
+        
       }
       if(col.eff == "random"){
         row.names(Br) <- colnames(spdr)
         if(!is.null(colnames(y))) colnames(Br) <- colnames(y)
         out$params$Br <- Br
+        if(nrow(Xt)==n){
         out$params$B <- B
         names(out$params$B) <- colnames(Xt)
+        }
         out$params$sigmaB <- diag(sigma.sp[1:ncol(spdr)], ncol(spdr))
         if(any(colMat[row(colMat)!=col(colMat)]!=0)){
           if(colMat.rho.struct == "term"){
@@ -2235,11 +2273,9 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
         }
         if(ncol(cs)==2){
           sigmaSPij <- rep(0,(ncol(spdr)^2-ncol(spdr))/2)
-          if(ncol(cs)>1){
             for(i in 1:nrow(cs)){
               sigmaSPij[(cs[i,1] - 1) * (cs[i,1] - 2) / 2 + cs[i,2]] = covsigma.sp[i]
             }
-          }
           SprL <- out$params$sigmaB%*%constructL(sigmaSPij)
           out$params$sigmaB <- SprL%*%t(SprL)
         }
@@ -2476,7 +2512,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, formula = NULL, family = "poisso
           out$Ab.lv <- AB_lv
         } 
         
-        if(row.eff=="random"){
+        if(nrow(dr)==n){
           lg_Ar <- param[names(param)=="lg_Ar"]
           Ar <- vector("list", length(nr))
           Ar.sds <- exp((lg_Ar)[1:sum(nr)])

--- a/R/gllvm.TMB.R
+++ b/R/gllvm.TMB.R
@@ -306,8 +306,7 @@ gllvm.TMB <- function(y, X = NULL, lv.X = NULL, xr = matrix(0), formula = NULL, 
   
     #### Calculate starting values
     if((num.lv.c+num.lv+num.RR)==0 && !is.null(RElist) || randomX.start=="zero") RElist <- NULL # calculating starting values for REs and LVs
-    if((nrow(xr)==n)||(nrow(dr)==n))row.eff = "random"
-    fit <- start_values_gllvm_TMB(y = y, xr = xr, dr = dr, X = Xorig, formula = formula, lv.X = lv.X, TR = NULL, family = family, offset= offset, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, start.lvs = start.lvs, starting.val = starting.val, Power = Power, jitter.var = jitter.var, row.eff = row.eff, TMB=TRUE, link=link, zeta.struc = zeta.struc, disp.group = disp.group, method=method, randomB = randomB, Ntrials = Ntrials, Ab.struct = sp.Ar.struc, Ab.struct.rank = sp.Ar.struc.rank, colMat = colMat.old, nn.colMat = nn.colMat, RElist = RElist, beta0com = beta0com)
+    fit <- start_values_gllvm_TMB(y = y, xr = xr, dr = dr, X = Xorig, formula = formula, lv.X = lv.X, TR = NULL, family = family, offset= offset, num.lv = num.lv, num.lv.c = num.lv.c, num.RR = num.RR, start.lvs = start.lvs, starting.val = starting.val, Power = Power, jitter.var = jitter.var, TMB=TRUE, link=link, zeta.struc = zeta.struc, disp.group = disp.group, method=method, randomB = randomB, Ntrials = Ntrials, Ab.struct = sp.Ar.struc, Ab.struct.rank = sp.Ar.struc.rank, colMat = colMat.old, nn.colMat = nn.colMat, RElist = RElist, beta0com = beta0com)
     
     if(is.null(fit$Power) && family == "tweedie")fit$Power=1.1
     if(family=="tweedie"){

--- a/R/gllvm.VA.R
+++ b/R/gllvm.VA.R
@@ -184,7 +184,10 @@ gllvm.VA <- function(y, X = NULL, TR = NULL, formula=NULL, family = "poisson",
   while(n.i<=n.init){
     if(n.init>1 && trace) cat("initial run ",n.i,"\n");
     set.seed(seed[n.i])
-    res <- start_values_gllvm_TMB(y = y, X = X1, TR = TR1, family = family, formula = formula, offset=offset, trial.size = trial.size, num.lv = num.lv, start.lvs = start.lvs, starting.val=starting.val, jitter.var=jitter.var, yXT=yXT, row.eff = row.eff, TMB=FALSE, link="probit",zeta.struc="species")
+    xr = dr = matrix(0)
+    if(row.eff == "random")dr <- diag(n)
+    if(row.eff == "fixed") xr <- model.matrix(~site, data.frame(site = factor(1:n)))[,-1,drop=FALSE]
+    res <- start_values_gllvm_TMB(y = y, X = X1, TR = TR1, family = family, formula = formula, offset=offset, trial.size = trial.size, num.lv = num.lv, start.lvs = start.lvs, starting.val=starting.val, jitter.var=jitter.var, yXT=yXT, TMB=FALSE, link="probit",zeta.struc="species")
     if(is.null(start.params)){
       new.beta0 <- beta0 <- res$params[,1]
       # common env params or different env response for each spp

--- a/R/gllvm.auxiliary.R
+++ b/R/gllvm.auxiliary.R
@@ -154,7 +154,18 @@ start_values_gllvm_TMB <- function(y, X = NULL, lv.X = NULL, TR=NULL, xr = matri
           formula=form1
         }
 
-        if(!TMB) fit.mva <- gllvm.VA(y, X = X, dr = dr, xr = xr, TR = TR, formula = formula(formula), family = family, num.lv = 0, Lambda.struc = "diagonal", trace = FALSE, plot = FALSE, sd.errors = FALSE, maxit = 1000, max.iter=200, n.init = 1, starting.val="zero", yXT = yXT)
+        if(!TMB){
+          if((nrow(dr)==n) && (ncol(dr) == n)){
+            row.eff = "random"
+          }
+          if((nrow(xr)==n) && (ncol(xr) == (n-1))){
+            row.eff = "fixed"
+          }
+          if((nrow(xr) == n) && (nrow(dr) == n)){
+            stop("Mixed row effects not allowed with TMB = 'FALSE'.")
+          }
+          fit.mva <- gllvm.VA(y, X = X, TR = TR, row.eff = row.eff, formula = formula(formula), family = family, num.lv = 0, Lambda.struc = "diagonal", trace = FALSE, plot = FALSE, sd.errors = FALSE, maxit = 1000, max.iter=200, n.init = 1, starting.val="zero", yXT = yXT)
+        } 
         if(TMB) {
           fit.mva <- try(trait.TMB(y, X = X, dr = dr, xr = xr, TR = TR, formula = formula(formula), family = family, num.lv = 0, Lambda.struc = "diagonal", trace = FALSE, maxit = 1000, max.iter=200, n.init=1,starting.val="zero",yXT = yXT, diag.iter = 0, optimizer = "nlminb", beta0com = beta0com, link = link, Power = Power, disp.group = disp.group, method = method, Ntrials = Ntrials), silent = TRUE);
           if(is.null(randomX) && inherits(fit.mva, "try-error") || is.null(randomX) && !is.finite(fit.mva$logL)){

--- a/R/logLik.gllvm.R
+++ b/R/logLik.gllvm.R
@@ -33,16 +33,21 @@ logLik.gllvm <- function(object, ...)
     object$params$inv.phi <- NULL
   }
     if(object$family=="ordinal"){
-      if(object$zeta.struc=="species")object$params$zeta<-object$params$zeta[,-1]
-      if(object$zeta.struc=="common")object$params$zeta<-object$params$zeta[-1]
+      if(object$zeta.struc=="species")object$params$zeta <-object$params$zeta[,-1]
+      if(object$zeta.struc=="common")object$params$zeta <-object$params$zeta[-1]
     }
-  if (object$row.eff %in% c("fixed", TRUE))
-    object$params$row.params <- object$params$row.params[-1]
-  if (object$row.eff == "random")
-    object$params$row.params <- NULL
-  if(is.null(object$beta0com))object$beta0com<-FALSE # backward compatibility
+  
+    # backward compatibility
+    
+    if(is.null(object$params$row.params.random) && !inherits(object$row.eff, "formula") && object$row.eff == "random")object$params$row.params.random <- object$params$row.params
+    if(is.null(object$beta0com))object$beta0com<-FALSE 
+    if(is.null(object$col.eff$col.eff))object$col.eff$col.eff <- FALSE
+    
+    # end backward compatibility
+    
+  if (!is.null(object$params$row.params.random))
+    object$params$row.params.random <- NULL
   if(object$beta0com) object$params$beta0 <- 1
-  if(is.null(object$col.eff$col.eff))object$col.eff$col.eff <- FALSE # backward compatibility
   if (!is.null(object$randomX) || object$col.eff$col.eff == "random"){
     object$params$Br <- NULL
     object$params$sigmaB <- object$params$sigmaB[lower.tri(object$params$sigmaB, diag = TRUE)]


### PR DESCRIPTION
See #184 amongst other things.

This PR:
- Allows for multiple fixed effects with covariates in "row.eff" (still retains the option row.eff="fixed" too)
- Allows "row.eff" to incorporate (random)slopes in the form of row.eff = ~cov1 or row.eff = ~(0+cov|1) or row.eff = ~(0+cov|group), ... also with more than one covariate of course (still retains the option row.eff="random" too)
- Note the "0+"; adding the possibility for a random intercept is not yet possible for technical reasons (see comment in gllvm.R). Although this functionality should largely be unnecessary, it would be nice to have this be a fully functional mixed-effects formula interface
- Between random effect correlation is not yet included (planned/to-do for a later time in the near future pending availability)
- Allows the  ~randomX to be specified more generally via the same (new) lme4-like interface for random effects of gllvm.TMB.R so that the random effects matrix in traitTMB.R can now also be (block)diagonal

This PR changes the foundations of row effects in gllvm, so that are many changes and edits, thus I expect some bugs to pop-up. Especially in cases where formula, lv.formula, and row.eff are used simultaneously, as there are a lot of combinations to test and I have not yet have had the possibility to go through them all..

The lines in gllvm.R

```
      } else if(!is.null(studyDesign) && any(colnames(studyDesign) %in% colnames(X))){
        X <- X[,-which(colnames(X)%in%colnames(studyDesign)),drop=F]
        if(ncol(X)==0)X<-NULL
      }
```

will likely be the main root of trouble. I previously added those lines as a fix to a bug, so that covariates do not make it through the formula interface unintended, and thus cannot be removed without consequence, but it is also clear that keeping them might have unwanted consequences here. E.g., when row.eff incorporates a random slope and X includes fixed-effects covariates, the model is technically valid and identifiable, but the interface will filter out the covariate from X anyway. Since I did not write a comment why I placed the code, and since I cannot remember, I do not have a straightforward solution at this time. The most straightforward solution might be to always require the "studyDesign" matrix to be used for row effects, "X" is never used for row effects, though this would prevent some previously written code including row effects (i.e., that specified via "X") to be incompatible with this newer version of gllvm.

Happy to get some suggestions from @JenniNiku here.


